### PR TITLE
user trust phase 0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,30 @@
+version: 2.1
+
+orbs:
+  coveralls: coveralls/coveralls@1.0.4
+
+jobs:
+  coverage:
+    docker:
+      - image: circleci/node:14.15.1
+      - image: circleci/postgres:12-alpine
+        environment:
+          POSTGRES_USER: citest
+          POSTGRES_DB: impactmarkettest
+          POSTGRES_PASSWORD: test101
+    steps:
+      - checkout
+      - run: yarn
+      - run:
+          name: "Run Tests and do Coverage Reports"
+          command: yarn coverage:ci
+          environment:
+            DATABASE_URL: postgresql://citest:test101@localhost:5432/impactmarkettest
+      - store_artifacts:
+          path: coverage
+
+workflows:
+  version: 2
+  test:
+    jobs:
+      - coverage

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "test": "NODE_ENV=test mocha",
         "coverage": "NODE_ENV=test nyc --reporter=html mocha",
         "precoverage:ci": "sequelize db:migrate --env ci --to z1605204805-create-beneficiaryTransaction.js",
-        "coverage:ci": "NODE_ENV=test nyc --reporter=text-lcov mocha | coveralls",
+        "coverage:ci": "NODE_ENV=test nyc --reporter=text-lcov mocha",
         "test:watch": "mocha --watch",
         "clean": "rm -rf dist coverage .nyc_output"
     },

--- a/src/api/controllers/community.ts
+++ b/src/api/controllers/community.ts
@@ -1,3 +1,4 @@
+import { RequestWithUser } from '@ipcttypes/core';
 import BeneficiaryService from '@services/beneficiary';
 import CommunityService from '@services/community';
 import CommunityDailyMetricsService from '@services/communityDailyMetrics';
@@ -65,28 +66,37 @@ const findBeneficiaryByAddress = (req: Request, res: Response) => {
         .catch((e) => res.status(404).send(e));
 };
 
-const searchBeneficiary = (req: Request, res: Response) => {
+const searchBeneficiary = (req: RequestWithUser, res: Response) => {
+    if (req.user === undefined) {
+        controllerLogAndFail('User not identified!', 400, res);
+        return;
+    }
     CommunityService.searchBeneficiary(
-        (req as any).user.address,
+        req.user.address,
         req.params.beneficiaryQuery,
-        req.params.active === 'true'
+        req.params.active ? req.params.active === 'true' : undefined
     )
         .then((r) => res.send(r))
         .catch((e) => res.status(404).send(e));
 };
 
-const searchManager = (req: Request, res: Response) => {
-    CommunityService.searchManager(
-        (req as any).user.address,
-        req.params.managerQuery
-    )
+const searchManager = (req: RequestWithUser, res: Response) => {
+    if (req.user === undefined) {
+        controllerLogAndFail('User not identified!', 400, res);
+        return;
+    }
+    CommunityService.searchManager(req.user.address, req.params.managerQuery)
         .then((r) => res.send(r))
         .catch((e) => res.status(404).send(e));
 };
 
-const listBeneficiaries = (req: Request, res: Response) => {
+const listBeneficiaries = (req: RequestWithUser, res: Response) => {
+    if (req.user === undefined) {
+        controllerLogAndFail('User not identified!', 400, res);
+        return;
+    }
     CommunityService.listBeneficiaries(
-        (req as any).user.address,
+        req.user.address,
         req.params.active === 'true',
         parseInt(req.params.offset, 10),
         parseInt(req.params.limit, 10)
@@ -95,9 +105,13 @@ const listBeneficiaries = (req: Request, res: Response) => {
         .catch((e) => controllerLogAndFail(e, 400, res));
 };
 
-const listManagers = (req: Request, res: Response) => {
+const listManagers = (req: RequestWithUser, res: Response) => {
+    if (req.user === undefined) {
+        controllerLogAndFail('User not identified!', 400, res);
+        return;
+    }
     CommunityService.listManagers(
-        (req as any).user.address,
+        req.user.address,
         parseInt(req.params.offset, 10),
         parseInt(req.params.limit, 10)
     )

--- a/src/api/controllers/community.ts
+++ b/src/api/controllers/community.ts
@@ -1,3 +1,4 @@
+import BeneficiaryService from '@services/beneficiary';
 import CommunityService from '@services/community';
 import CommunityDailyMetricsService from '@services/communityDailyMetrics';
 import ManagerService from '@services/managers';
@@ -56,6 +57,12 @@ const listFull = (req: Request, res: Response) => {
     CommunityService.listFull(req.params.order)
         .then((r) => res.send(r))
         .catch((e) => controllerLogAndFail(e, 400, res));
+};
+
+const findBeneficiaryByAddress = (req: Request, res: Response) => {
+    BeneficiaryService.findByAddress(req.params.address)
+        .then((r) => res.send(r))
+        .catch((e) => res.status(404).send(e));
 };
 
 const searchBeneficiary = (req: Request, res: Response) => {
@@ -217,6 +224,7 @@ export default {
     getHistoricalSSI,
     list,
     listFull,
+    findBeneficiaryByAddress,
     searchBeneficiary,
     searchManager,
     listBeneficiaries,

--- a/src/api/controllers/user.ts
+++ b/src/api/controllers/user.ts
@@ -33,14 +33,14 @@ class UserController {
     };
 
     public hello = (req: Request, res: Response) => {
-        const { address, token } = req.body;
+        const { address, token, phone } = req.body;
         if (token.length > 0) {
             // failing to set the push notification, should not be a blocker!
             UserService.setPushNotificationsToken(address, token).catch((e) =>
                 Logger.warn(`Error setting push notification token ` + e)
             );
         }
-        UserService.hello(address)
+        UserService.hello(address, phone)
             .then((u) => res.send(u))
             .catch((e) => controllerLogAndFail(e, 403, res));
     };

--- a/src/api/controllers/user.ts
+++ b/src/api/controllers/user.ts
@@ -14,12 +14,19 @@ class UserController {
     };
 
     public authenticate = (req: Request, res: Response) => {
-        const { address, language, currency, pushNotificationToken } = req.body;
+        const {
+            address,
+            language,
+            currency,
+            pushNotificationToken,
+            phone,
+        } = req.body;
         UserService.authenticate(
             address,
             language,
             currency,
-            pushNotificationToken
+            pushNotificationToken,
+            phone
         )
             .then((user) => res.send(user))
             .catch((e) => res.status(403).send(e));

--- a/src/api/routes/community.ts
+++ b/src/api/routes/community.ts
@@ -17,6 +17,11 @@ export default (app: Router): void => {
     route.get('/contract/:address', communityController.getByContractAddress);
     route.get('/hssi/:publicId', communityController.getHistoricalSSI);
     route.get(
+        '/beneficiaries/find/:address',
+        authenticateToken,
+        communityController.findBeneficiaryByAddress
+    );
+    route.get(
         '/beneficiaries/search/:active/:beneficiaryQuery',
         authenticateToken,
         communityController.searchBeneficiary

--- a/src/api/routes/community.ts
+++ b/src/api/routes/community.ts
@@ -16,11 +16,46 @@ export default (app: Router): void => {
     route.get('/publicid/:publicId', communityController.getByPublicId);
     route.get('/contract/:address', communityController.getByContractAddress);
     route.get('/hssi/:publicId', communityController.getHistoricalSSI);
+    /**
+     * @swagger
+     *
+     * /community/beneficiaries/find/{beneficiaryQuery}/{active}:
+     *   get:
+     *     tags:
+     *       - "community"
+     *     summary: Find a beneficiary in manager's community
+     *     parameters:
+     *       - in: path
+     *         name: beneficiaryQuery
+     *         schema:
+     *           type: string
+     *         required: true
+     *         description: Address or (part of) name
+     *       - in: path
+     *         name: active
+     *         schema:
+     *           type: boolean
+     *         required: false
+     *         description: Active, inactive or irrelevante (not defined)
+     *     responses:
+     *       "200":
+     *         description: OK
+     *     security:
+     *     - api_auth:
+     *       - "write:modify":
+     */
     route.get(
-        '/beneficiaries/find/:address',
+        '/beneficiaries/find/:beneficiaryQuery/:active?',
         authenticateToken,
-        communityController.findBeneficiaryByAddress
+        communityController.searchBeneficiary
     );
+
+    /**
+     * @swagger
+     *
+     * /community/beneficiaries/search/{active}/beneficiaryQuery:
+     *   deprecated: true
+     */
     route.get(
         '/beneficiaries/search/:active/:beneficiaryQuery',
         authenticateToken,
@@ -53,20 +88,6 @@ export default (app: Router): void => {
         authenticateToken,
         communityController.managersDetails
     );
-    /**
-     * @swagger
-     *
-     * /list/light/{order}:
-     *   get:
-     *     tags:
-     *       - "community"
-     *     produces:
-     *       - application/json
-     *     parameters:
-     *       - name: order
-     *         in: path
-     *         type: string
-     */
     route.get('/list/light/:order?', communityController.list);
     route.get('/list/full/:order?', communityController.listFull);
     route.post(

--- a/src/api/routes/storage.ts
+++ b/src/api/routes/storage.ts
@@ -27,7 +27,7 @@ export default (app: Router): void => {
         try {
             upload.single('imageFile')(req, res, async (err) => {
                 if (err) {
-                    Logger.error('Error during /storage/upload ', err);
+                    Logger.error('Error during /storage/upload ' + err);
                     res.sendStatus(403);
                 }
 
@@ -93,7 +93,7 @@ export default (app: Router): void => {
                 res.sendStatus(200);
             });
         } catch (e) {
-            Logger.error('Error during /upload ', e);
+            Logger.error('Error during /upload ' + e);
             res.sendStatus(403);
         }
     });

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -81,6 +81,10 @@ export default (app: express.Application): void => {
                         name: 'story',
                         description: 'Manage stories',
                     },
+                    {
+                        name: 'community',
+                        description: 'UBI communities',
+                    },
                 ],
                 servers: swaggerServers,
                 schemes: [urlSchema],

--- a/src/api/validators/user.ts
+++ b/src/api/validators/user.ts
@@ -13,6 +13,7 @@ const authenticate = celebrate({
         language: Joi.string().required(),
         currency: Joi.string().optional().allow(''),
         pushNotificationToken: Joi.string().required().allow(''),
+        phone: Joi.string().optional(),
     }),
 });
 

--- a/src/api/validators/user.ts
+++ b/src/api/validators/user.ts
@@ -11,64 +11,65 @@ const authenticate = celebrate({
     body: Joi.object({
         address: Joi.string().required(),
         language: Joi.string().required(),
-        currency: Joi.string().optional().allow(''),
+        currency: Joi.string().required(),
         pushNotificationToken: Joi.string().required().allow(''),
-        phone: Joi.string().optional(),
+        phone: Joi.string().optional(), // TODO: make it required once 1.0.7 is the minimal mobile version!
     }),
 });
 
 const hello = celebrate({
     body: Joi.object({
-        address: Joi.string().required(),
+        address: Joi.string().optional(), // TODO: remove it once 1.0.7 is the minimal mobile version!
         token: Joi.string().allow(''),
+        phone: Joi.string().optional(), // TODO: remove it once 1.0.7 is the minimal mobile version!
     }),
 });
 
 const updateUsername = celebrate({
     body: Joi.object({
-        address: Joi.string().required(),
+        address: Joi.string().optional(), // TODO: remove it once 1.0.7 is the minimal mobile version!
         username: Joi.string().required().allow(''),
     }),
 });
 
 const updateCurrency = celebrate({
     body: Joi.object({
-        address: Joi.string().required(),
+        address: Joi.string().optional(), // TODO: remove it once 1.0.7 is the minimal mobile version!
         currency: Joi.string().required(),
     }),
 });
 
 const updatePushNotificationsToken = celebrate({
     body: Joi.object({
-        address: Joi.string().required(),
+        address: Joi.string().optional(), // TODO: remove it once 1.0.7 is the minimal mobile version!
         token: Joi.string().required(),
     }),
 });
 
 const updateLanguage = celebrate({
     body: Joi.object({
-        address: Joi.string().required(),
+        address: Joi.string().optional(), // TODO: remove it once 1.0.7 is the minimal mobile version!
         language: Joi.string().required(),
     }),
 });
 
 const updateGender = celebrate({
     body: Joi.object({
-        address: Joi.string().required(),
+        address: Joi.string().optional(), // TODO: remove it once 1.0.7 is the minimal mobile version!
         gender: Joi.string().required().allow(''),
     }),
 });
 
 const updateAge = celebrate({
     body: Joi.object({
-        address: Joi.string().required(),
+        address: Joi.string().optional(), // TODO: remove it once 1.0.7 is the minimal mobile version!
         age: Joi.number().required().allow(null),
     }),
 });
 
 const updateChildren = celebrate({
     body: Joi.object({
-        address: Joi.string().required(),
+        address: Joi.string().optional(), // TODO: remove it once 1.0.7 is the minimal mobile version!
         children: Joi.number().required().allow(null),
     }),
 });

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -34,13 +34,15 @@ import { AppUserDeviceModel } from '@models/app/userDevice';
 import { AppAnonymousReportModel } from '@models/app/anonymousReport';
 import { UbiRequestChangeParamsModel } from '@models/UBI/requestChangeParams';
 import { StoryUserReportModel } from '@models/story/storyUserReport';
+import { AppUserThroughTrustModel } from '@models/app/appUserThroughTrust';
+import { AppUserTrustModel } from '@models/app/appUserTrust';
 
 let logging:
     | boolean
     | ((sql: string, timing?: number | undefined) => void)
     | undefined;
 if (process.env.NODE_ENV === 'development') {
-    logging = (msg) => false;
+    logging = (msg) => console.log(msg);
 } else {
     logging = (msg) => Logger.verbose(msg);
 }
@@ -55,6 +57,10 @@ const sequelize = new Sequelize(config.dbUrl, dbConfig);
 initModels(sequelize);
 const models: DbModels = {
     user: sequelize.models.UserModel as ModelCtor<UserModel>,
+    appUserTrust: sequelize.models
+        .AppUserTrustModel as ModelCtor<AppUserTrustModel>,
+    appUserThroughTrust: sequelize.models
+        .AppUserThroughTrustModel as ModelCtor<AppUserThroughTrustModel>,
     community: sequelize.models.Community as ModelCtor<Community>,
     communityContract: sequelize.models
         .CommunityContract as ModelCtor<CommunityContract>,

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -36,6 +36,7 @@ import { UbiRequestChangeParamsModel } from '@models/UBI/requestChangeParams';
 import { StoryUserReportModel } from '@models/story/storyUserReport';
 import { AppUserThroughTrustModel } from '@models/app/appUserThroughTrust';
 import { AppUserTrustModel } from '@models/app/appUserTrust';
+import { UbiCommunitySuspectModel } from '@models/UBI/ubiCommunitySuspect';
 
 let logging:
     | boolean
@@ -62,6 +63,8 @@ const models: DbModels = {
     appUserThroughTrust: sequelize.models
         .AppUserThroughTrustModel as ModelCtor<AppUserThroughTrustModel>,
     community: sequelize.models.Community as ModelCtor<Community>,
+    ubiCommunitySuspect: sequelize.models
+        .UbiCommunitySuspectModel as ModelCtor<UbiCommunitySuspectModel>,
     communityContract: sequelize.models
         .CommunityContract as ModelCtor<CommunityContract>,
     communityState: sequelize.models

--- a/src/database/migrations/create-user.js
+++ b/src/database/migrations/create-user.js
@@ -11,7 +11,7 @@ module.exports = {
                 type: Sequelize.STRING(128),
             },
             language: {
-                type:Sequelize.STRING(8),
+                type: Sequelize.STRING(8),
                 allowNull: false,
             },
             currency: {
@@ -30,6 +30,11 @@ module.exports = {
             children: {
                 type: Sequelize.INTEGER,
             },
+            lastLogin: {
+                type: Sequelize.DATE,
+                defaultValue: Sequelize.fn('now'),
+                allowNull: false,
+            },
             createdAt: {
                 allowNull: false,
                 type: Sequelize.DATE,
@@ -37,10 +42,10 @@ module.exports = {
             updatedAt: {
                 allowNull: false,
                 type: Sequelize.DATE,
-            }
+            },
         });
     },
     down: (queryInterface, Sequelize) => {
         return queryInterface.dropTable('user');
-    }
+    },
 };

--- a/src/database/migrations/z1603464322-create-beneficiary.js
+++ b/src/database/migrations/z1603464322-create-beneficiary.js
@@ -1,7 +1,7 @@
 'use strict';
 module.exports = {
     up: async (queryInterface, Sequelize) => {
-        await  queryInterface.createTable('beneficiary', {
+        await queryInterface.createTable('beneficiary', {
             id: {
                 type: Sequelize.INTEGER,
                 autoIncrement: true,
@@ -9,6 +9,11 @@ module.exports = {
             },
             address: {
                 type: Sequelize.STRING(44),
+                references: {
+                    model: 'user',
+                    key: 'address',
+                },
+                onDelete: 'RESTRICT', // delete only if active = false, separately
                 allowNull: false,
             },
             communityId: {
@@ -18,12 +23,15 @@ module.exports = {
                     key: 'publicId',
                 },
                 onDelete: 'RESTRICT',
-                allowNull: false
+                allowNull: false,
             },
             active: {
                 type: Sequelize.BOOLEAN,
                 defaultValue: true,
-                allowNull: false,
+            },
+            blocked: {
+                type: Sequelize.BOOLEAN,
+                defaultValue: false,
             },
             tx: {
                 type: Sequelize.STRING(68),
@@ -54,11 +62,13 @@ module.exports = {
             updatedAt: {
                 allowNull: false,
                 type: Sequelize.DATE,
-            }
+            },
         });
-        return queryInterface.sequelize.query(`ALTER TABLE beneficiary ADD CONSTRAINT one_beneficiary_per_community_key UNIQUE (address, "communityId");`)
+        return queryInterface.sequelize.query(
+            `ALTER TABLE beneficiary ADD CONSTRAINT one_beneficiary_per_community_key UNIQUE (address, "communityId");`
+        );
     },
     down: (queryInterface, Sequelize) => {
         return queryInterface.dropTable('beneficiary');
-    }
+    },
 };

--- a/src/database/migrations/z1613043841-create-triggers.js
+++ b/src/database/migrations/z1613043841-create-triggers.js
@@ -40,6 +40,7 @@ EXECUTE PROCEDURE update_beneficiaries_community_states();`);
         CREATE OR REPLACE FUNCTION update_claim_states()
     RETURNS TRIGGER AS $$
     declare
+        beneficiary_claimed numeric(22);
         state_claimed numeric(29);
         state_daily_claimed numeric(29);
         beneficiary_last_claim_at timestamp with time zone;
@@ -48,8 +49,8 @@ EXECUTE PROCEDURE update_beneficiaries_community_states();`);
         UPDATE communitystate SET claims = claims + 1 WHERE "communityId"=NEW."communityId";
         UPDATE communitydailystate SET claims = claims + 1 WHERE "communityId"=NEW."communityId" AND date=DATE(NEW."txAt");
         -- update beneficiary table as well
-        SELECT "lastClaimAt" INTO beneficiary_last_claim_at FROM beneficiary WHERE "communityId"=NEW."communityId" AND address=NEW.address;
-        UPDATE beneficiary SET claims = claims + 1, "penultimateClaimAt"=beneficiary_last_claim_at, "lastClaimAt"=NEW."txAt" WHERE "communityId"=NEW."communityId" AND address=NEW.address;
+        SELECT "lastClaimAt", SUM(claimed + NEW.amount) INTO beneficiary_last_claim_at, beneficiary_claimed FROM beneficiary WHERE "communityId"=NEW."communityId" AND address=NEW.address;
+        UPDATE beneficiary SET claims = claims + 1, "penultimateClaimAt"=beneficiary_last_claim_at, "lastClaimAt"=NEW."txAt", claimed = beneficiary_claimed WHERE "communityId"=NEW."communityId" AND address=NEW.address;
         -- update total claimed
         SELECT SUM(claimed + NEW.amount) INTO state_claimed FROM communitystate WHERE "communityId"=NEW."communityId";
         UPDATE communitystate SET claimed = state_claimed WHERE "communityId"=NEW."communityId";

--- a/src/database/migrations/z1615057322-create-appUserDevice.js
+++ b/src/database/migrations/z1615057322-create-appUserDevice.js
@@ -13,7 +13,7 @@ module.exports = {
                     model: 'user',
                     key: 'address',
                 },
-                onDelete: 'RESTRICT',
+                onDelete: 'CASCADE',
                 allowNull: false,
             },
             phone: {

--- a/src/database/migrations/z1615980962-update-user.js
+++ b/src/database/migrations/z1615980962-update-user.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await queryInterface.addColumn('user', 'lastLogin', {
+            type: Sequelize.DATE,
+            defaultValue: Sequelize.fn('now'),
+            allowNull: false,
+        });
+    },
+
+    down(queryInterface, Sequelize) {},
+};

--- a/src/database/migrations/z1615980972-update-beneficiary.js
+++ b/src/database/migrations/z1615980972-update-beneficiary.js
@@ -4,7 +4,7 @@ module.exports = {
     async up(queryInterface, Sequelize) {
         await queryInterface.addColumn('beneficiary', 'blocked', {
             type: Sequelize.BOOLEAN,
-            defaultValue: true,
+            defaultValue: false,
         });
         await queryInterface.addColumn('beneficiary', 'claimed', {
             type: Sequelize.DECIMAL(22), // max 9,999 - plus 18 decimals

--- a/src/database/migrations/z1615980972-update-beneficiary.js
+++ b/src/database/migrations/z1615980972-update-beneficiary.js
@@ -6,6 +6,10 @@ module.exports = {
             type: Sequelize.BOOLEAN,
             defaultValue: true,
         });
+        await queryInterface.addColumn('beneficiary', 'claimed', {
+            type: Sequelize.DECIMAL(22), // max 9,999 - plus 18 decimals
+            defaultValue: 0,
+        });
     },
 
     down(queryInterface, Sequelize) {},

--- a/src/database/migrations/z1615980972-update-beneficiary.js
+++ b/src/database/migrations/z1615980972-update-beneficiary.js
@@ -1,0 +1,12 @@
+'use strict';
+
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await queryInterface.addColumn('beneficiary', 'blocked', {
+            type: Sequelize.BOOLEAN,
+            defaultValue: true,
+        });
+    },
+
+    down(queryInterface, Sequelize) {},
+};

--- a/src/database/migrations/z1615981201-create-appUserTrust.js
+++ b/src/database/migrations/z1615981201-create-appUserTrust.js
@@ -1,0 +1,24 @@
+'use strict';
+module.exports = {
+    up(queryInterface, Sequelize) {
+        return queryInterface.createTable('AppUserTrust', {
+            id: {
+                type: Sequelize.INTEGER,
+                autoIncrement: true,
+                primaryKey: true,
+            },
+            phone: {
+                // hashed phone number
+                type: Sequelize.STRING(64),
+                allowNull: false,
+            },
+            verifiedPhoneNumber: {
+                type: Sequelize.BOOLEAN,
+                defaultValue: false,
+            },
+        });
+    },
+    down(queryInterface, Sequelize) {
+        return queryInterface.dropTable('AppUserTrust');
+    },
+};

--- a/src/database/migrations/z1615981201-create-appUserTrust.js
+++ b/src/database/migrations/z1615981201-create-appUserTrust.js
@@ -1,7 +1,7 @@
 'use strict';
 module.exports = {
     up(queryInterface, Sequelize) {
-        return queryInterface.createTable('AppUserTrust', {
+        return queryInterface.createTable('app_user_trust', {
             id: {
                 type: Sequelize.INTEGER,
                 autoIncrement: true,
@@ -23,6 +23,6 @@ module.exports = {
         });
     },
     down(queryInterface, Sequelize) {
-        return queryInterface.dropTable('AppUserTrust');
+        return queryInterface.dropTable('app_user_trust');
     },
 };

--- a/src/database/migrations/z1615981201-create-appUserTrust.js
+++ b/src/database/migrations/z1615981201-create-appUserTrust.js
@@ -16,6 +16,10 @@ module.exports = {
                 type: Sequelize.BOOLEAN,
                 defaultValue: false,
             },
+            suspect: {
+                type: Sequelize.BOOLEAN,
+                defaultValue: false,
+            },
         });
     },
     down(queryInterface, Sequelize) {

--- a/src/database/migrations/z1615981221-create-appUserThroughTrust.js
+++ b/src/database/migrations/z1615981221-create-appUserThroughTrust.js
@@ -1,0 +1,28 @@
+'use strict';
+module.exports = {
+    up(queryInterface, Sequelize) {
+        return queryInterface.createTable('AppUserThroughTrust', {
+            userAddress: {
+                type: Sequelize.STRING(44),
+                references: {
+                    model: 'user',
+                    key: 'address',
+                },
+                onDelete: 'CASCADE',
+                allowNull: false,
+            },
+            appUserTrustPhone: {
+                type: Sequelize.STRING(64),
+                // references: {
+                //     model: 'AppUserTrust',
+                //     key: 'phone',
+                // },
+                // onDelete: 'CASCADE',
+                allowNull: false,
+            },
+        });
+    },
+    down(queryInterface, Sequelize) {
+        return queryInterface.dropTable('AppUserThroughTrust');
+    },
+};

--- a/src/database/migrations/z1615981221-create-appUserThroughTrust.js
+++ b/src/database/migrations/z1615981221-create-appUserThroughTrust.js
@@ -11,13 +11,13 @@ module.exports = {
                 onDelete: 'CASCADE',
                 allowNull: false,
             },
-            appUserTrustPhone: {
-                type: Sequelize.STRING(64),
-                // references: {
-                //     model: 'AppUserTrust',
-                //     key: 'phone',
-                // },
-                // onDelete: 'CASCADE',
+            appUserTrustId: {
+                type: Sequelize.INTEGER,
+                references: {
+                    model: 'AppUserTrust',
+                    key: 'id',
+                },
+                onDelete: 'CASCADE',
                 allowNull: false,
             },
         });

--- a/src/database/migrations/z1615981221-create-appUserThroughTrust.js
+++ b/src/database/migrations/z1615981221-create-appUserThroughTrust.js
@@ -1,7 +1,7 @@
 'use strict';
 module.exports = {
     up(queryInterface, Sequelize) {
-        return queryInterface.createTable('AppUserThroughTrust', {
+        return queryInterface.createTable('app_user_through_trust', {
             userAddress: {
                 type: Sequelize.STRING(44),
                 references: {
@@ -14,7 +14,7 @@ module.exports = {
             appUserTrustId: {
                 type: Sequelize.INTEGER,
                 references: {
-                    model: 'AppUserTrust',
+                    model: 'app_user_trust',
                     key: 'id',
                 },
                 onDelete: 'CASCADE',
@@ -23,6 +23,6 @@ module.exports = {
         });
     },
     down(queryInterface, Sequelize) {
-        return queryInterface.dropTable('AppUserThroughTrust');
+        return queryInterface.dropTable('app_user_through_trust');
     },
 };

--- a/src/database/migrations/z1616074997-update-triggers.js
+++ b/src/database/migrations/z1616074997-update-triggers.js
@@ -1,0 +1,34 @@
+'use strict';
+
+// eslint-disable-next-line no-undef
+module.exports = {
+    up(queryInterface, Sequelize) {
+        // use datagrip for better understanding + highlight
+
+        return queryInterface.sequelize.query(`
+        CREATE OR REPLACE FUNCTION update_claim_states()
+    RETURNS TRIGGER AS $$
+    declare
+        beneficiary_claimed numeric(22);
+        state_claimed numeric(29);
+        state_daily_claimed numeric(29);
+        beneficiary_last_claim_at timestamp with time zone;
+    BEGIN
+        -- update claims
+        UPDATE communitystate SET claims = claims + 1 WHERE "communityId"=NEW."communityId";
+        UPDATE communitydailystate SET claims = claims + 1 WHERE "communityId"=NEW."communityId" AND date=DATE(NEW."txAt");
+        -- update beneficiary table as well
+        SELECT "lastClaimAt", SUM(claimed + NEW.amount) INTO beneficiary_last_claim_at, beneficiary_claimed FROM beneficiary WHERE "communityId"=NEW."communityId" AND address=NEW.address;
+        UPDATE beneficiary SET claims = claims + 1, "penultimateClaimAt"=beneficiary_last_claim_at, "lastClaimAt"=NEW."txAt", claimed = beneficiary_claimed WHERE "communityId"=NEW."communityId" AND address=NEW.address;
+        -- update total claimed
+        SELECT SUM(claimed + NEW.amount) INTO state_claimed FROM communitystate WHERE "communityId"=NEW."communityId";
+        UPDATE communitystate SET claimed = state_claimed WHERE "communityId"=NEW."communityId";
+        SELECT SUM(claimed + NEW.amount) INTO state_daily_claimed FROM communitydailystate WHERE "communityId"=NEW."communityId" AND date=DATE(NEW."txAt");
+        UPDATE communitydailystate SET claimed = state_daily_claimed WHERE "communityId"=NEW."communityId" AND date=DATE(NEW."txAt");
+        return NEW;
+    END;
+$$ LANGUAGE plpgsql;`);
+    },
+
+    down(queryInterface, Sequelize) {},
+};

--- a/src/database/migrations/z1616077405-update-beneficiary.js
+++ b/src/database/migrations/z1616077405-update-beneficiary.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const BigNumber = require('bignumber.js');
+BigNumber.config({ EXPONENTIAL_AT: [-7, 30] });
+// eslint-disable-next-line no-undef
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        const r = await queryInterface.sequelize.query(
+            `select COALESCE(sum(amount), 0) claimed, address, "communityId"
+            from claim group by address, "communityId"`,
+            { raw: true, type: Sequelize.QueryTypes.SELECT }
+        );
+
+        for (let index = 0; index < r.length; index++) {
+            const e = r[index];
+            await queryInterface.sequelize.query(
+                `update beneficiary set claimed = cast('${e.claimed}' as decimal)
+                where address = '${e.address}'
+                and "communityId" = '${e.communityId}'`,
+                { raw: true, type: Sequelize.QueryTypes.SELECT }
+            );
+        }
+    },
+
+    down(queryInterface, Sequelize) {},
+};

--- a/src/database/migrations/z1616267799-create-ubiCommunitySuspect.js
+++ b/src/database/migrations/z1616267799-create-ubiCommunitySuspect.js
@@ -1,0 +1,32 @@
+'use strict';
+module.exports = {
+    up(queryInterface, Sequelize) {
+        return queryInterface.createTable('ubi_community_suspect', {
+            id: {
+                type: Sequelize.INTEGER,
+                autoIncrement: true,
+                primaryKey: true,
+            },
+            communityId: {
+                type: Sequelize.INTEGER,
+                references: {
+                    model: 'community',
+                    key: 'id',
+                },
+                onDelete: 'CASCADE',
+                allowNull: false,
+            },
+            suspect: {
+                type: Sequelize.INTEGER,
+                allowNull: false,
+            },
+            createdAt: {
+                type: Sequelize.DATEONLY,
+                defaultValue: Sequelize.fn('now'),
+            },
+        });
+    },
+    down(queryInterface, Sequelize) {
+        return queryInterface.dropTable('ubi_community_suspect');
+    },
+};

--- a/src/database/migrations_config/config.js
+++ b/src/database/migrations_config/config.js
@@ -21,7 +21,7 @@ module.exports = {
         password: 'test101',
         database: 'impactmarkettest',
         host: 'localhost',
-        port: 5433,
+        port: 5432,
         dialect: 'postgres',
     },
     test: {

--- a/src/database/models/UBI/ubiCommunitySuspect.ts
+++ b/src/database/models/UBI/ubiCommunitySuspect.ts
@@ -1,0 +1,49 @@
+import {
+    UbiCommunitySuspect,
+    UbiCommunitySuspectCreation,
+} from '@interfaces/UBI/ubiCommunitySuspect';
+import { Sequelize, DataTypes, Model } from 'sequelize';
+
+export class UbiCommunitySuspectModel extends Model<
+    UbiCommunitySuspect,
+    UbiCommunitySuspectCreation
+> {
+    public id!: number;
+    public communityId!: number;
+    public suspect!: number;
+    public createdAt!: Date;
+}
+
+export function initializeUbiCommunitySuspect(sequelize: Sequelize): void {
+    UbiCommunitySuspectModel.init(
+        {
+            id: {
+                type: DataTypes.INTEGER,
+                autoIncrement: true,
+                primaryKey: true,
+            },
+            communityId: {
+                type: DataTypes.INTEGER,
+                references: {
+                    model: 'community',
+                    key: 'id',
+                },
+                onDelete: 'CASCADE',
+                allowNull: false,
+            },
+            suspect: {
+                type: DataTypes.INTEGER,
+                allowNull: false,
+            },
+            createdAt: {
+                type: DataTypes.DATEONLY,
+                defaultValue: Sequelize.fn('now'),
+            },
+        },
+        {
+            tableName: 'ubi_community_suspect',
+            timestamps: false,
+            sequelize,
+        }
+    );
+}

--- a/src/database/models/app/appUserThroughTrust.ts
+++ b/src/database/models/app/appUserThroughTrust.ts
@@ -27,7 +27,7 @@ export function initializeAppUserThroughTrust(sequelize: Sequelize): void {
             appUserTrustId: {
                 type: DataTypes.INTEGER,
                 references: {
-                    model: 'AppUserTrust',
+                    model: 'app_user_trust',
                     key: 'id',
                 },
                 onDelete: 'CASCADE',
@@ -35,7 +35,7 @@ export function initializeAppUserThroughTrust(sequelize: Sequelize): void {
             },
         },
         {
-            tableName: 'AppUserThroughTrust',
+            tableName: 'app_user_through_trust',
             timestamps: false,
             sequelize,
         }

--- a/src/database/models/app/appUserThroughTrust.ts
+++ b/src/database/models/app/appUserThroughTrust.ts
@@ -1,0 +1,43 @@
+import {
+    AppUserThroughTrust,
+    AppUserThroughTrustCreation,
+} from '@interfaces/app/appUserThroughTrust';
+import { Sequelize, DataTypes, Model } from 'sequelize';
+
+export class AppUserThroughTrustModel extends Model<
+    AppUserThroughTrust,
+    AppUserThroughTrustCreation
+> {
+    public userAddress!: string;
+    public appUserTrustPhone!: string;
+}
+
+export function initializeAppUserThroughTrust(sequelize: Sequelize): void {
+    AppUserThroughTrustModel.init(
+        {
+            userAddress: {
+                type: DataTypes.STRING(44),
+                references: {
+                    model: 'user',
+                    key: 'address',
+                },
+                onDelete: 'CASCADE',
+                allowNull: false,
+            },
+            appUserTrustPhone: {
+                type: DataTypes.STRING(64),
+                // references: {
+                //     model: 'AppUserTrust',
+                //     key: 'phone',
+                // },
+                // onDelete: 'CASCADE',
+                allowNull: false,
+            },
+        },
+        {
+            tableName: 'AppUserThroughTrust',
+            timestamps: false,
+            sequelize,
+        }
+    );
+}

--- a/src/database/models/app/appUserThroughTrust.ts
+++ b/src/database/models/app/appUserThroughTrust.ts
@@ -9,7 +9,7 @@ export class AppUserThroughTrustModel extends Model<
     AppUserThroughTrustCreation
 > {
     public userAddress!: string;
-    public appUserTrustPhone!: string;
+    public appUserTrustId!: string;
 }
 
 export function initializeAppUserThroughTrust(sequelize: Sequelize): void {
@@ -24,13 +24,13 @@ export function initializeAppUserThroughTrust(sequelize: Sequelize): void {
                 onDelete: 'CASCADE',
                 allowNull: false,
             },
-            appUserTrustPhone: {
-                type: DataTypes.STRING(64),
-                // references: {
-                //     model: 'AppUserTrust',
-                //     key: 'phone',
-                // },
-                // onDelete: 'CASCADE',
+            appUserTrustId: {
+                type: DataTypes.INTEGER,
+                references: {
+                    model: 'AppUserTrust',
+                    key: 'id',
+                },
+                onDelete: 'CASCADE',
                 allowNull: false,
             },
         },

--- a/src/database/models/app/appUserTrust.ts
+++ b/src/database/models/app/appUserTrust.ts
@@ -1,0 +1,40 @@
+import {
+    AppUserTrust,
+    AppUserTrustCreation,
+} from '@interfaces/app/appUserTrust';
+import { Sequelize, DataTypes, Model } from 'sequelize';
+
+export class AppUserTrustModel extends Model<
+    AppUserTrust,
+    AppUserTrustCreation
+> {
+    public id!: number;
+    public phone!: string;
+    public verifiedPhoneNumber!: boolean;
+}
+
+export function initializeAppUserTrust(sequelize: Sequelize): void {
+    AppUserTrustModel.init(
+        {
+            id: {
+                type: DataTypes.INTEGER,
+                autoIncrement: true,
+                primaryKey: true,
+            },
+            phone: {
+                // hashed phone number
+                type: DataTypes.STRING(64),
+                allowNull: false,
+            },
+            verifiedPhoneNumber: {
+                type: DataTypes.BOOLEAN,
+                defaultValue: false,
+            },
+        },
+        {
+            tableName: 'AppUserTrust',
+            timestamps: false,
+            sequelize,
+        }
+    );
+}

--- a/src/database/models/app/appUserTrust.ts
+++ b/src/database/models/app/appUserTrust.ts
@@ -37,7 +37,7 @@ export function initializeAppUserTrust(sequelize: Sequelize): void {
             },
         },
         {
-            tableName: 'AppUserTrust',
+            tableName: 'app_user_trust',
             timestamps: false,
             sequelize,
         }

--- a/src/database/models/app/appUserTrust.ts
+++ b/src/database/models/app/appUserTrust.ts
@@ -11,6 +11,7 @@ export class AppUserTrustModel extends Model<
     public id!: number;
     public phone!: string;
     public verifiedPhoneNumber!: boolean;
+    public suspect!: boolean;
 }
 
 export function initializeAppUserTrust(sequelize: Sequelize): void {
@@ -27,6 +28,10 @@ export function initializeAppUserTrust(sequelize: Sequelize): void {
                 allowNull: false,
             },
             verifiedPhoneNumber: {
+                type: DataTypes.BOOLEAN,
+                defaultValue: false,
+            },
+            suspect: {
                 type: DataTypes.BOOLEAN,
                 defaultValue: false,
             },

--- a/src/database/models/associations/community.ts
+++ b/src/database/models/associations/community.ts
@@ -1,0 +1,12 @@
+import { Sequelize } from 'sequelize';
+
+export function communityAssociation(sequelize: Sequelize) {
+    // used to query from the community with incude
+    sequelize.models.Community.hasMany(
+        sequelize.models.UbiCommunitySuspectModel,
+        {
+            foreignKey: 'communityId',
+            as: 'suspect',
+        }
+    );
+}

--- a/src/database/models/associations/community.ts
+++ b/src/database/models/associations/community.ts
@@ -9,4 +9,10 @@ export function communityAssociation(sequelize: Sequelize) {
             as: 'suspect',
         }
     );
+    // used to query from the community with incude
+    sequelize.models.Community.hasMany(sequelize.models.Beneficiary, {
+        foreignKey: 'communityId',
+        sourceKey: 'publicId',
+        as: 'beneficiaries',
+    });
 }

--- a/src/database/models/associations/user.ts
+++ b/src/database/models/associations/user.ts
@@ -28,6 +28,7 @@ export function userAssociation(sequelize: Sequelize) {
             as: 'throughTrust',
         }
     );
+    // used to query from the AppUserTrust with incude
     sequelize.models.AppUserTrustModel.belongsToMany(
         sequelize.models.UserModel,
         {
@@ -37,6 +38,7 @@ export function userAssociation(sequelize: Sequelize) {
             as: 'throughTrust',
         }
     );
+    // self association to find repeated values on those keys
     sequelize.models.AppUserTrustModel.hasMany(
         sequelize.models.AppUserTrustModel,
         {
@@ -45,4 +47,11 @@ export function userAssociation(sequelize: Sequelize) {
             as: 'selfTrust',
         }
     );
+
+    // beneficiaries are linked to manager through communityId
+    sequelize.models.Beneficiary.belongsTo(sequelize.models.Manager, {
+        foreignKey: 'communityId',
+        targetKey: 'communityId',
+        as: 'manager',
+    });
 }

--- a/src/database/models/associations/user.ts
+++ b/src/database/models/associations/user.ts
@@ -1,0 +1,40 @@
+import { Sequelize } from 'sequelize';
+
+export function userAssociation(sequelize: Sequelize) {
+    // used to query from the user with incude
+    sequelize.models.UserModel.hasMany(sequelize.models.Beneficiary, {
+        foreignKey: 'address',
+        as: 'beneficiary',
+    });
+    // used to query from the beneficiary with incude
+    sequelize.models.Beneficiary.belongsTo(sequelize.models.UserModel, {
+        foreignKey: 'address',
+        as: 'user',
+    });
+
+    // used to query from the user with incude
+    sequelize.models.UserModel.hasMany(sequelize.models.Manager, {
+        foreignKey: 'user',
+        as: 'manager',
+    });
+
+    // used to query from the user with incude
+    sequelize.models.UserModel.belongsToMany(
+        sequelize.models.AppUserTrustModel,
+        {
+            through: sequelize.models.AppUserThroughTrustModel,
+            foreignKey: 'userAddress',
+            sourceKey: 'address',
+            as: 'throughTrust',
+        }
+    );
+    sequelize.models.AppUserTrustModel.belongsToMany(
+        sequelize.models.UserModel,
+        {
+            through: sequelize.models.AppUserThroughTrustModel,
+            foreignKey: 'appUserTrustPhone',
+            sourceKey: 'phone',
+            as: 'throughTrust',
+        }
+    );
+}

--- a/src/database/models/associations/user.ts
+++ b/src/database/models/associations/user.ts
@@ -32,9 +32,17 @@ export function userAssociation(sequelize: Sequelize) {
         sequelize.models.UserModel,
         {
             through: sequelize.models.AppUserThroughTrustModel,
-            foreignKey: 'appUserTrustPhone',
-            sourceKey: 'phone',
+            foreignKey: 'appUserTrustId',
+            sourceKey: 'id',
             as: 'throughTrust',
+        }
+    );
+    sequelize.models.AppUserTrustModel.hasMany(
+        sequelize.models.AppUserTrustModel,
+        {
+            foreignKey: 'phone',
+            sourceKey: 'phone',
+            as: 'selfTrust',
         }
     );
 }

--- a/src/database/models/beneficiary.ts
+++ b/src/database/models/beneficiary.ts
@@ -1,6 +1,7 @@
+import { User } from '@interfaces/user';
 import { Sequelize, DataTypes, Model } from 'sequelize';
 
-interface BeneficiaryAttributes {
+export interface BeneficiaryAttributes {
     id: number;
     address: string;
     communityId: string;
@@ -9,12 +10,15 @@ interface BeneficiaryAttributes {
     tx: string;
     txAt: Date;
     claims: number;
+    claimed: string;
     lastClaimAt: Date | null;
     penultimateClaimAt: Date | null;
 
     // timestamps
     createdAt: Date;
     updatedAt: Date;
+
+    user?: User;
 }
 interface BeneficiaryCreationAttributes {
     address: string;
@@ -35,6 +39,7 @@ export class Beneficiary extends Model<
     public tx!: string;
     public txAt!: Date;
     public claims!: number;
+    public claimed!: string;
     public lastClaimAt!: Date | null;
     public penultimateClaimAt!: Date | null;
 
@@ -89,7 +94,10 @@ export function initializeBeneficiary(sequelize: Sequelize): void {
             claims: {
                 type: DataTypes.INTEGER,
                 defaultValue: 0,
-                allowNull: false,
+            },
+            claimed: {
+                type: DataTypes.DECIMAL(22), // max 9,999 - plus 18 decimals
+                defaultValue: 0,
             },
             lastClaimAt: {
                 type: DataTypes.DATE,

--- a/src/database/models/beneficiary.ts
+++ b/src/database/models/beneficiary.ts
@@ -5,6 +5,7 @@ interface BeneficiaryAttributes {
     address: string;
     communityId: string;
     active: boolean;
+    blocked: boolean;
     tx: string;
     txAt: Date;
     claims: number;
@@ -30,6 +31,7 @@ export class Beneficiary extends Model<
     public address!: string;
     public communityId!: string;
     public active!: boolean;
+    public blocked!: boolean;
     public tx!: string;
     public txAt!: Date;
     public claims!: number;
@@ -51,6 +53,11 @@ export function initializeBeneficiary(sequelize: Sequelize): void {
             },
             address: {
                 type: DataTypes.STRING(44),
+                references: {
+                    model: 'user',
+                    key: 'address',
+                },
+                onDelete: 'RESTRICT', // delete only if active = false, separately
                 allowNull: false,
             },
             communityId: {
@@ -65,7 +72,10 @@ export function initializeBeneficiary(sequelize: Sequelize): void {
             active: {
                 type: DataTypes.BOOLEAN,
                 defaultValue: true,
-                allowNull: false,
+            },
+            blocked: {
+                type: DataTypes.BOOLEAN,
+                defaultValue: true,
             },
             tx: {
                 type: DataTypes.STRING(68),

--- a/src/database/models/community.ts
+++ b/src/database/models/community.ts
@@ -1,4 +1,5 @@
 import { StoryCommunity } from '@interfaces/story/storyCommunity';
+import { UbiCommunitySuspect } from '@interfaces/UBI/ubiCommunitySuspect';
 import { Sequelize, DataTypes, Model } from 'sequelize';
 
 import { ICommunityVars } from '../../types';
@@ -31,6 +32,7 @@ export interface CommunityAttributes {
     updatedAt: Date;
 
     storyCommunity?: StoryCommunity[];
+    suspect?: UbiCommunitySuspect[];
 }
 export interface CommunityCreationAttributes {
     requestByAddress: string;

--- a/src/database/models/community.ts
+++ b/src/database/models/community.ts
@@ -3,6 +3,7 @@ import { UbiCommunitySuspect } from '@interfaces/UBI/ubiCommunitySuspect';
 import { Sequelize, DataTypes, Model } from 'sequelize';
 
 import { ICommunityVars } from '../../types';
+import { BeneficiaryAttributes } from './beneficiary';
 
 export interface CommunityAttributes {
     id: number; // Note that the `null assertion` `!` is required in strict mode.
@@ -33,6 +34,7 @@ export interface CommunityAttributes {
 
     storyCommunity?: StoryCommunity[];
     suspect?: UbiCommunitySuspect[];
+    beneficiaries?: BeneficiaryAttributes[];
 }
 export interface CommunityCreationAttributes {
     requestByAddress: string;

--- a/src/database/models/exchangeRates.ts
+++ b/src/database/models/exchangeRates.ts
@@ -1,6 +1,6 @@
 import { Sequelize, DataTypes, Model } from 'sequelize';
 
-interface ExchangeRatesAttributes {
+export interface ExchangeRatesAttributes {
     currency: string;
     rate: number;
 

--- a/src/database/models/index.ts
+++ b/src/database/models/index.ts
@@ -178,12 +178,18 @@ export default function initModels(sequelize: Sequelize): void {
             {
                 model: sequelize.models.AppUserTrustModel,
                 as: 'throughTrust',
+                include: [
+                    {
+                        model: sequelize.models.AppUserTrustModel,
+                        as: 'selfTrust',
+                    },
+                ],
             },
         ],
         where: {
             address: '0x7110b4Df915cb92F53Bc01cC9Ab15F51e5DBb52F',
         },
-    }).then(console.log);
+    }).then((x: any) => console.log(x?.toJSON()?.throughTrust));
 
     // this actually works, but eager loading not so much!
     // sequelize.models.Manager.belongsTo(sequelize.models.User, {

--- a/src/database/models/index.ts
+++ b/src/database/models/index.ts
@@ -33,6 +33,9 @@ import { initializeStoryEngagement } from './story/storyEngagement';
 import { initializeStoryUserEngagement } from './story/storyUserEngagement';
 import { initializeAppAnonymousReport } from './app/anonymousReport';
 import { initializeStoryUserReport } from './story/storyUserReport';
+import { userAssociation } from './associations/user';
+import { initializeAppUserThroughTrust } from './app/appUserThroughTrust';
+import { initializeAppUserTrust } from './app/appUserTrust';
 
 export default function initModels(sequelize: Sequelize): void {
     initializeSubscribers(sequelize);
@@ -41,6 +44,8 @@ export default function initModels(sequelize: Sequelize): void {
     initializeSSI(sequelize);
     initializeTransactions(sequelize);
     initializeUser(sequelize);
+    initializeAppUserTrust(sequelize);
+    initializeAppUserThroughTrust(sequelize);
     initializeAppUserDevice(sequelize);
     initializeAgenda(sequelize);
     initializeClaimLocation(sequelize);
@@ -149,6 +154,36 @@ export default function initModels(sequelize: Sequelize): void {
             as: 'storyUserReport',
         }
     );
+
+    userAssociation(sequelize);
+
+    // sequelize.models.AppUserTrustModel.create({
+    //     phone:
+    //         'b96000f4543a5c7c3d75e72626324e785270e078c5a25013a15895097bd1d818',
+    // }).then(async (newTrust) => {
+    //     const user = await sequelize.models.UserModel.findOne({
+    //         where: {
+    //             address: '0x7110b4Df915cb92F53Bc01cC9Ab15F51e5DBb52F',
+    //         },
+    //     });
+    //     await (user as any).addAppUserTrustModel(newTrust);
+    // });
+
+    sequelize.models.UserModel.findOne({
+        include: [
+            {
+                model: sequelize.models.Beneficiary,
+                as: 'beneficiary',
+            },
+            {
+                model: sequelize.models.AppUserTrustModel,
+                as: 'throughTrust',
+            },
+        ],
+        where: {
+            address: '0x7110b4Df915cb92F53Bc01cC9Ab15F51e5DBb52F',
+        },
+    }).then(console.log);
 
     // this actually works, but eager loading not so much!
     // sequelize.models.Manager.belongsTo(sequelize.models.User, {

--- a/src/database/models/index.ts
+++ b/src/database/models/index.ts
@@ -157,40 +157,6 @@ export default function initModels(sequelize: Sequelize): void {
 
     userAssociation(sequelize);
 
-    // sequelize.models.AppUserTrustModel.create({
-    //     phone:
-    //         'b96000f4543a5c7c3d75e72626324e785270e078c5a25013a15895097bd1d818',
-    // }).then(async (newTrust) => {
-    //     const user = await sequelize.models.UserModel.findOne({
-    //         where: {
-    //             address: '0x7110b4Df915cb92F53Bc01cC9Ab15F51e5DBb52F',
-    //         },
-    //     });
-    //     await (user as any).addAppUserTrustModel(newTrust);
-    // });
-
-    sequelize.models.UserModel.findOne({
-        include: [
-            {
-                model: sequelize.models.Beneficiary,
-                as: 'beneficiary',
-            },
-            {
-                model: sequelize.models.AppUserTrustModel,
-                as: 'throughTrust',
-                include: [
-                    {
-                        model: sequelize.models.AppUserTrustModel,
-                        as: 'selfTrust',
-                    },
-                ],
-            },
-        ],
-        where: {
-            address: '0x7110b4Df915cb92F53Bc01cC9Ab15F51e5DBb52F',
-        },
-    }).then((x: any) => console.log(x?.toJSON()?.throughTrust));
-
     // this actually works, but eager loading not so much!
     // sequelize.models.Manager.belongsTo(sequelize.models.User, {
     //     foreignKey: 'user',

--- a/src/database/models/index.ts
+++ b/src/database/models/index.ts
@@ -36,11 +36,14 @@ import { initializeStoryUserReport } from './story/storyUserReport';
 import { userAssociation } from './associations/user';
 import { initializeAppUserThroughTrust } from './app/appUserThroughTrust';
 import { initializeAppUserTrust } from './app/appUserTrust';
+import { communityAssociation } from './associations/community';
+import { initializeUbiCommunitySuspect } from './UBI/ubiCommunitySuspect';
 
 export default function initModels(sequelize: Sequelize): void {
     initializeSubscribers(sequelize);
-    initializeUbiRequestChangeParams(sequelize);
     initializeCommunity(sequelize);
+    initializeUbiCommunitySuspect(sequelize);
+    initializeUbiRequestChangeParams(sequelize);
     initializeSSI(sequelize);
     initializeTransactions(sequelize);
     initializeUser(sequelize);
@@ -156,6 +159,7 @@ export default function initModels(sequelize: Sequelize): void {
     );
 
     userAssociation(sequelize);
+    communityAssociation(sequelize);
 
     // this actually works, but eager loading not so much!
     // sequelize.models.Manager.belongsTo(sequelize.models.User, {

--- a/src/database/models/manager.ts
+++ b/src/database/models/manager.ts
@@ -1,6 +1,6 @@
 import { Sequelize, DataTypes, Model } from 'sequelize';
 
-interface ManagerAttributes {
+export interface ManagerAttributes {
     id: number;
     user: string;
     communityId: string;

--- a/src/database/models/user.ts
+++ b/src/database/models/user.ts
@@ -1,12 +1,5 @@
-import { User } from '@interfaces/user';
+import { User, UserCreationAttributes } from '@interfaces/user';
 import { Sequelize, DataTypes, Model } from 'sequelize';
-
-export interface UserCreationAttributes {
-    address: string;
-    language: string;
-    currency?: string;
-    pushNotificationToken: string;
-}
 
 export class UserModel extends Model<User, UserCreationAttributes> {
     public address!: string;
@@ -18,7 +11,7 @@ export class UserModel extends Model<User, UserCreationAttributes> {
     public gender!: string;
     public year!: number | null;
     public children!: number | null;
-    public readonly lastLogin!: Date;
+    public lastLogin!: Date;
 
     // timestamps!
     public readonly createdAt!: Date;

--- a/src/database/models/user.ts
+++ b/src/database/models/user.ts
@@ -18,6 +18,7 @@ export class UserModel extends Model<User, UserCreationAttributes> {
     public gender!: string;
     public year!: number | null;
     public children!: number | null;
+    public readonly lastLogin!: Date;
 
     // timestamps!
     public readonly createdAt!: Date;
@@ -55,6 +56,11 @@ export default function (sequelize: Sequelize): typeof UserModel {
             },
             children: {
                 type: DataTypes.INTEGER,
+            },
+            lastLogin: {
+                type: DataTypes.DATE,
+                defaultValue: Sequelize.fn('now'),
+                allowNull: false,
             },
             createdAt: {
                 type: DataTypes.DATE,

--- a/src/interfaces/UBI/ubiCommunitySuspect.ts
+++ b/src/interfaces/UBI/ubiCommunitySuspect.ts
@@ -4,4 +4,7 @@ export interface UbiCommunitySuspect {
     suspect: number;
     createdAt: boolean;
 }
-export interface UbiCommunitySuspectCreation {}
+export interface UbiCommunitySuspectCreation {
+    communityId: number;
+    suspect: number;
+}

--- a/src/interfaces/UBI/ubiCommunitySuspect.ts
+++ b/src/interfaces/UBI/ubiCommunitySuspect.ts
@@ -1,0 +1,7 @@
+export interface UbiCommunitySuspect {
+    id: number;
+    communityId: number;
+    suspect: number;
+    createdAt: boolean;
+}
+export interface UbiCommunitySuspectCreation {}

--- a/src/interfaces/app/appUserThroughTrust.ts
+++ b/src/interfaces/app/appUserThroughTrust.ts
@@ -2,4 +2,7 @@ export interface AppUserThroughTrust {
     userAddress: string;
     appUserTrustId: number;
 }
-export interface AppUserThroughTrustCreation {}
+export interface AppUserThroughTrustCreation {
+    userAddress: string;
+    appUserTrustId: number;
+}

--- a/src/interfaces/app/appUserThroughTrust.ts
+++ b/src/interfaces/app/appUserThroughTrust.ts
@@ -1,5 +1,5 @@
 export interface AppUserThroughTrust {
     userAddress: string;
-    appUserTrustPhone: number;
+    appUserTrustId: number;
 }
 export interface AppUserThroughTrustCreation {}

--- a/src/interfaces/app/appUserThroughTrust.ts
+++ b/src/interfaces/app/appUserThroughTrust.ts
@@ -1,0 +1,5 @@
+export interface AppUserThroughTrust {
+    userAddress: string;
+    appUserTrustPhone: number;
+}
+export interface AppUserThroughTrustCreation {}

--- a/src/interfaces/app/appUserTrust.ts
+++ b/src/interfaces/app/appUserTrust.ts
@@ -1,3 +1,5 @@
+import { AppUserThroughTrustCreation } from './appUserThroughTrust';
+
 export interface AppUserTrust {
     id: number;
     phone: string;
@@ -8,4 +10,5 @@ export interface AppUserTrust {
 }
 export interface AppUserTrustCreation {
     phone: string;
+    throughTrust?: AppUserThroughTrustCreation;
 }

--- a/src/interfaces/app/appUserTrust.ts
+++ b/src/interfaces/app/appUserTrust.ts
@@ -2,6 +2,7 @@ export interface AppUserTrust {
     id: number;
     phone: string;
     verifiedPhoneNumber: boolean;
+    suspect: boolean;
 
     selfTrust?: AppUserTrust[];
 }

--- a/src/interfaces/app/appUserTrust.ts
+++ b/src/interfaces/app/appUserTrust.ts
@@ -2,6 +2,8 @@ export interface AppUserTrust {
     id: number;
     phone: string;
     verifiedPhoneNumber: boolean;
+
+    selfTrust?: AppUserTrust[];
 }
 export interface AppUserTrustCreation {
     phone: string;

--- a/src/interfaces/app/appUserTrust.ts
+++ b/src/interfaces/app/appUserTrust.ts
@@ -1,0 +1,8 @@
+export interface AppUserTrust {
+    id: number;
+    phone: string;
+    verifiedPhoneNumber: boolean;
+}
+export interface AppUserTrustCreation {
+    phone: string;
+}

--- a/src/interfaces/user.ts
+++ b/src/interfaces/user.ts
@@ -7,6 +7,7 @@ export interface User {
     gender: string;
     year: number | null;
     children: number | null;
+    lastLogin: Date;
 
     // timestamps
     createdAt: Date;

--- a/src/interfaces/user.ts
+++ b/src/interfaces/user.ts
@@ -1,3 +1,5 @@
+import { AppUserTrust } from './app/appUserTrust';
+
 export interface User {
     address: string;
     username: string | null;
@@ -12,4 +14,6 @@ export interface User {
     // timestamps
     createdAt: Date;
     updatedAt: Date;
+
+    throughTrust?: AppUserTrust[];
 }

--- a/src/interfaces/user.ts
+++ b/src/interfaces/user.ts
@@ -27,6 +27,4 @@ export interface UserCreationAttributes {
     language: string;
     currency?: string;
     pushNotificationToken: string;
-
-    throughTrust?: AppUserTrustCreation[];
 }

--- a/src/interfaces/user.ts
+++ b/src/interfaces/user.ts
@@ -1,4 +1,6 @@
-import { AppUserTrust } from './app/appUserTrust';
+import { BeneficiaryAttributes } from '@models/beneficiary';
+import { ManagerAttributes } from '@models/manager';
+import { AppUserTrust, AppUserTrustCreation } from './app/appUserTrust';
 
 export interface User {
     address: string;
@@ -16,4 +18,15 @@ export interface User {
     updatedAt: Date;
 
     throughTrust?: AppUserTrust[];
+    beneficiary?: BeneficiaryAttributes[];
+    manager?: ManagerAttributes[];
+}
+
+export interface UserCreationAttributes {
+    address: string;
+    language: string;
+    currency?: string;
+    pushNotificationToken: string;
+
+    throughTrust?: AppUserTrustCreation[];
 }

--- a/src/services/beneficiary.ts
+++ b/src/services/beneficiary.ts
@@ -19,37 +19,33 @@ export default class BeneficiaryService {
         tx: string,
         txAt: Date
     ): Promise<boolean> {
-        // if user does not exist, add to pending list
-        // otherwise update
-        const user = await this.beneficiary.findOne({
-            where: { address, active: false },
-            raw: true,
-        });
-        if (user === null) {
-            const beneficiaryData = {
-                address,
-                communityId,
-                tx,
-                txAt,
-            };
-            try {
-                await this.beneficiary.create(beneficiaryData);
-            } catch (e) {
-                if (e.name !== 'SequelizeUniqueConstraintError') {
-                    Logger.error(
-                        'Error inserting new Beneficiary. Data = ' +
-                            JSON.stringify(beneficiaryData)
-                    );
-                    Logger.error(e);
-                }
+        const beneficiaryData = {
+            address,
+            communityId,
+            tx,
+            txAt,
+        };
+        try {
+            await this.beneficiary.create(beneficiaryData);
+        } catch (e) {
+            if (e.name !== 'SequelizeUniqueConstraintError') {
+                Logger.error(
+                    'Error inserting new Beneficiary. Data = ' +
+                        JSON.stringify(beneficiaryData)
+                );
+                Logger.error(e);
             }
-        } else {
-            await this.beneficiary.update(
-                { active: true },
-                { where: { address } }
-            );
         }
         return true;
+    }
+
+    public static findByAddress(
+        address: string,
+        active?: boolean
+    ): Promise<Beneficiary | null> {
+        return this.beneficiary.findOne({
+            where: { address, active },
+        });
     }
 
     public static async getAllAddressesInPublicValidCommunities(): Promise<
@@ -258,13 +254,6 @@ export default class BeneficiaryService {
             active,
             inactive,
         };
-    }
-
-    public static async get(address: string): Promise<Beneficiary | null> {
-        return await this.beneficiary.findOne({
-            where: { address, active: true },
-            raw: true,
-        });
     }
 
     public static async getAllAddresses(): Promise<string[]> {

--- a/src/services/beneficiary.ts
+++ b/src/services/beneficiary.ts
@@ -184,9 +184,12 @@ export default class BeneficiaryService {
                     b.user?.throughTrust?.length !== 0
                         ? b.user?.throughTrust![0].verifiedPhoneNumber
                         : undefined,
-                repeatedPN:
+                suspect:
                     b.user?.throughTrust?.length !== 0
-                        ? b.user?.throughTrust![0].selfTrust?.length
+                        ? b.user?.throughTrust![0].selfTrust
+                            ? b.user?.throughTrust![0].selfTrust?.length > 1 ||
+                              b.user?.throughTrust![0].suspect
+                            : undefined
                         : undefined,
             };
         });
@@ -266,9 +269,12 @@ export default class BeneficiaryService {
                     b.user?.throughTrust?.length !== 0
                         ? b.user?.throughTrust![0].verifiedPhoneNumber
                         : undefined,
-                repeatedPN:
+                suspect:
                     b.user?.throughTrust?.length !== 0
-                        ? b.user?.throughTrust![0].selfTrust?.length
+                        ? b.user?.throughTrust![0].selfTrust
+                            ? b.user?.throughTrust![0].selfTrust?.length > 1 ||
+                              b.user?.throughTrust![0].suspect
+                            : undefined
                         : undefined,
             };
         });

--- a/src/services/community.ts
+++ b/src/services/community.ts
@@ -656,7 +656,7 @@ export default class CommunityService {
     public static async searchBeneficiary(
         managerAddress: string,
         beneficiaryQuery: string,
-        active: boolean
+        active?: boolean
     ): Promise<IManagerDetailsBeneficiary[]> {
         return await BeneficiaryService.search(
             managerAddress,

--- a/src/services/community.ts
+++ b/src/services/community.ts
@@ -38,6 +38,7 @@ export default class CommunityService {
     public static communityState = models.communityState;
     public static communityDailyMetrics = models.communityDailyMetrics;
     public static ubiRequestChangeParams = models.ubiRequestChangeParams;
+    public static ubiCommunitySuspect = models.ubiCommunitySuspect;
     public static sequelize = sequelize;
 
     public static async create(
@@ -725,12 +726,19 @@ export default class CommunityService {
     public static async getByPublicId(
         publicId: string
     ): Promise<ICommunity | null> {
-        const community = await this.community.findOne({
+        const rawCommunity = await this.community.findAll({
+            include: [
+                {
+                    model: this.ubiCommunitySuspect,
+                    as: 'suspect',
+                    // TODO: just the most recent, in this case
+                },
+            ],
             where: {
                 publicId,
             },
-            raw: true,
         });
+        const community = rawCommunity[0].toJSON() as CommunityAttributes;
         if (community === null) {
             throw new Error('Not found community ' + publicId);
         }

--- a/src/services/exchangeRates.ts
+++ b/src/services/exchangeRates.ts
@@ -1,59 +1,13 @@
+import { ExchangeRatesAttributes } from '@models/exchangeRates';
 import { models } from '../database';
 
 export default class ExchangeRatesService {
     public static exchangeRates = models.exchangeRates;
 
-    public static async get(): Promise<{ exchangeRates: any; rates: any }> {
-        const rates = await this.exchangeRates.findAll({
+    public static get(): Promise<ExchangeRatesAttributes[]> {
+        return this.exchangeRates.findAll({
             attributes: ['currency', 'rate'],
             raw: true,
         });
-        const mapRates = {};
-        for (let index = 0; index < rates.length; index++) {
-            mapRates[rates[index].currency] = rates[index].rate;
-        }
-        const exchangeRates = {
-            EUR: {
-                name: 'Euro',
-                rate: mapRates['EUR'],
-            },
-            USD: {
-                name: 'American Dollar',
-                rate: 1,
-            },
-            BRL: {
-                name: 'Real Brasileiro',
-                rate: mapRates['BRL'],
-            },
-            GHS: {
-                name: 'Ghanaian Cedi',
-                rate: mapRates['GHS'],
-            },
-            CVE: {
-                name: 'Escudo Cabo Verde',
-                rate: mapRates['CVE'],
-            },
-            NGN: {
-                name: 'Nigerian Naira',
-                rate: mapRates['NGN'],
-            },
-            ARS: {
-                name: 'Peso Argentino',
-                rate: mapRates['ARS'],
-            },
-            VES: {
-                name: 'Bolívar Venezuelano',
-                rate: mapRates['VES'],
-            },
-            HNL: {
-                name: 'Honduran Lempira',
-                rate: mapRates['HNL'],
-            },
-            PHP: {
-                name: 'Philippine Peso',
-                rate: mapRates['PHP'],
-            },
-        };
-        return { exchangeRates, rates };
     }
 }

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -49,7 +49,7 @@ export default class UserService {
                     { where: { address } }
                 );
             }
-            const loadedUser = await UserService.loadUser(user);
+            const loadedUser = await UserService.loadUser(user.address);
             return {
                 user,
                 token,
@@ -66,7 +66,7 @@ export default class UserService {
         if (user === null) {
             throw new Error(address + ' user not found!');
         }
-        return await UserService.loadUser(user);
+        return await UserService.loadUser(user.address);
     }
 
     public static async setUsername(
@@ -229,17 +229,20 @@ export default class UserService {
     /**
      * TODO: improve
      */
-    private static async loadUser(user: User): Promise<IUserHello> {
+    private static async loadUser(userAddress: string): Promise<IUserHello> {
         let community: ICommunity | undefined;
         let communityId: string | undefined;
         let isBeneficiary = false;
         let isManager = false;
-        const beneficiary = await BeneficiaryService.get(user.address);
+        const beneficiary = await BeneficiaryService.findByAddress(
+            userAddress,
+            true
+        );
         if (beneficiary) {
             isBeneficiary = true;
             communityId = beneficiary.communityId;
         }
-        const manager = await ManagerService.get(user.address);
+        const manager = await ManagerService.get(userAddress);
         if (manager) {
             isManager = true;
             communityId = manager.communityId;
@@ -253,7 +256,7 @@ export default class UserService {
             }
         } else {
             const _communityId = await CommunityService.findByFirstManager(
-                user.address
+                userAddress
             );
             if (_communityId !== null) {
                 const _community = await CommunityService.getByPublicId(

--- a/src/types/db.ts
+++ b/src/types/db.ts
@@ -29,9 +29,13 @@ import { AppUserDeviceModel } from '@models/app/userDevice';
 import { AppAnonymousReportModel } from '@models/app/anonymousReport';
 import { UbiRequestChangeParamsModel } from '@models/UBI/requestChangeParams';
 import { StoryUserReportModel } from '@models/story/storyUserReport';
+import { AppUserThroughTrustModel } from '@models/app/appUserThroughTrust';
+import { AppUserTrustModel } from '@models/app/appUserTrust';
 
 export interface DbModels {
     user: ModelCtor<UserModel>;
+    appUserTrust: ModelCtor<AppUserTrustModel>;
+    appUserThroughTrust: ModelCtor<AppUserThroughTrustModel>;
     community: ModelCtor<Community>;
     communityContract: ModelCtor<CommunityContract>;
     communityState: ModelCtor<CommunityState>;

--- a/src/types/db.ts
+++ b/src/types/db.ts
@@ -31,12 +31,14 @@ import { UbiRequestChangeParamsModel } from '@models/UBI/requestChangeParams';
 import { StoryUserReportModel } from '@models/story/storyUserReport';
 import { AppUserThroughTrustModel } from '@models/app/appUserThroughTrust';
 import { AppUserTrustModel } from '@models/app/appUserTrust';
+import { UbiCommunitySuspectModel } from '@models/UBI/ubiCommunitySuspect';
 
 export interface DbModels {
     user: ModelCtor<UserModel>;
     appUserTrust: ModelCtor<AppUserTrustModel>;
     appUserThroughTrust: ModelCtor<AppUserThroughTrustModel>;
     community: ModelCtor<Community>;
+    ubiCommunitySuspect: ModelCtor<UbiCommunitySuspectModel>;
     communityContract: ModelCtor<CommunityContract>;
     communityState: ModelCtor<CommunityState>;
     communityDailyState: ModelCtor<CommunityDailyState>;

--- a/src/types/endpoints.ts
+++ b/src/types/endpoints.ts
@@ -53,8 +53,9 @@ export interface IManagerDetailsBeneficiary {
     timestamp: number;
     claimed: string;
     blocked: boolean;
+    // to users not yet registered, the values below do not exist
     verifiedPN: boolean | undefined;
-    repeatedPN: number | undefined;
+    suspect: boolean | undefined;
 }
 
 export interface IManagersDetails {

--- a/src/types/endpoints.ts
+++ b/src/types/endpoints.ts
@@ -3,6 +3,7 @@ import { CommunityAttributes } from '@models/community';
 import { CommunityContractAttributes } from '@models/communityContract';
 import { CommunityDailyMetricsAttributes } from '@models/communityDailyMetrics';
 import { CommunityStateAttributes } from '@models/communityState';
+import { ExchangeRatesAttributes } from '@models/exchangeRates';
 
 export interface ICommunityLightDetails {
     publicId: string;
@@ -67,14 +68,14 @@ export interface IManagersDetails {
 }
 
 export interface IUserHello {
-    /**
-     * @deprecated
-     */
-    exchangeRates: any; // TODO: remove when 1.0.0 is the lowest version required
-    rates: { currency: string; rate: number }[];
+    rates: ExchangeRatesAttributes[];
     isBeneficiary: boolean;
     isManager: boolean;
     community?: ICommunity;
+    blocked: boolean;
+    // to users not yet registered, the values below do not exist
+    verifiedPN: boolean | undefined;
+    suspect: boolean | undefined;
 }
 
 export interface IUserAuth extends IUserHello {

--- a/src/types/endpoints.ts
+++ b/src/types/endpoints.ts
@@ -52,6 +52,9 @@ export interface IManagerDetailsBeneficiary {
     username: string | null;
     timestamp: number;
     claimed: string;
+    blocked: boolean;
+    verifiedPN: boolean | undefined;
+    repeatedPN: number | undefined;
 }
 
 export interface IManagersDetails {

--- a/src/worker/jobs.ts
+++ b/src/worker/jobs.ts
@@ -12,6 +12,7 @@ import {
     calcuateCommunitiesMetrics,
     populateCommunityDailyState,
     verifyCommunityFunds,
+    verifyCommunitySuspectActivity,
 } from './jobs/cron/community';
 import { calcuateGlobalMetrics } from './jobs/cron/global';
 import { verifyStoriesLifecycle } from './jobs/cron/stories';
@@ -153,7 +154,7 @@ function cron() {
                         );
                     })
                     .catch((e) => {
-                        Logger.error('updateExchangeRates FAILED!', e);
+                        Logger.error('updateExchangeRates FAILED! ' + e);
                     });
             },
             null,
@@ -171,7 +172,7 @@ function cron() {
                     Logger.info('verifyCommunityFunds successfully executed!');
                 })
                 .catch((e) => {
-                    Logger.error('verifyCommunityFunds FAILED!', e);
+                    Logger.error('verifyCommunityFunds FAILED! ' + e);
                 });
         },
         null,
@@ -197,14 +198,30 @@ function cron() {
                             );
                         })
                         .catch((e) => {
-                            Logger.error('calcuateGlobalMetrics FAILED!', e);
+                            Logger.error('calcuateGlobalMetrics FAILED! ' + e);
                         });
                     Logger.info(
                         'calcuateCommunitiesMetrics successfully executed!'
                     );
                 })
                 .catch((e) => {
-                    Logger.error('calcuateCommunitiesMetrics FAILED!', e);
+                    Logger.error('calcuateCommunitiesMetrics FAILED! ' + e);
+                });
+        },
+        null,
+        true
+    );
+
+    new CronJob(
+        '0 0 * * *',
+        () => {
+            GlobalDemographicsService.calculateDemographics()
+                .then(() => {
+                    CronJobExecutedService.add('calculateDemographics');
+                    Logger.info('calculateDemographics successfully executed!');
+                })
+                .catch((e) => {
+                    Logger.error('calculateDemographics FAILED! ' + e);
                 });
         },
         null,
@@ -215,7 +232,7 @@ function cron() {
     new CronJob(
         '0 1 * * *',
         () => {
-            Logger.info('Calculating community metrics...');
+            Logger.info('Verify stories...');
             verifyStoriesLifecycle()
                 .then(() => {
                     CronJobExecutedService.add('verifyStoriesLifecycle');
@@ -224,24 +241,29 @@ function cron() {
                     );
                 })
                 .catch((e) => {
-                    Logger.error('verifyStoriesLifecycle FAILED!', e);
+                    Logger.error('verifyStoriesLifecycle FAILED! ' + e);
                 });
         },
         null,
         true
     );
 
-    // at 00:00 on thursday.
+    // at 5:12 am.
     new CronJob(
-        '0 0 * * *',
+        '12 5 * * *',
         () => {
-            GlobalDemographicsService.calculateDemographics()
+            Logger.info('Verify community suspicious activity...');
+            verifyCommunitySuspectActivity()
                 .then(() => {
-                    CronJobExecutedService.add('calculateDemographics');
-                    Logger.info('calculateDemographics successfully executed!');
+                    CronJobExecutedService.add(
+                        'verifyCommunitySuspectActivity'
+                    );
+                    Logger.info(
+                        'verifyCommunitySuspectActivity successfully executed!'
+                    );
                 })
                 .catch((e) => {
-                    Logger.error('calculateDemographics FAILED!', e);
+                    Logger.error('verifyCommunitySuspectActivity FAILED! ' + e);
                 });
         },
         null,
@@ -260,7 +282,7 @@ function cron() {
                     );
                 })
                 .catch((e) => {
-                    Logger.error('populateCommunityDailyState FAILED!', e);
+                    Logger.error('populateCommunityDailyState FAILED! ' + e);
                 });
         },
         null,


### PR DESCRIPTION
```javascript
export interface IManagerDetailsBeneficiary {
    address: string;
    username: string | null;
    timestamp: number;
    claimed: string;
    blocked: boolean;
    // this new fields can be null during this transition phase
    verifiedPN: boolean | undefined;
    suspect: boolean | undefined;
}

export interface IUserHello {
    rates: ExchangeRatesAttributes[];
    isBeneficiary: boolean;
    isManager: boolean;
    community?: ICommunity;
    blocked: boolean;
    // this new fields can be null during this transition phase
    verifiedPN: boolean | undefined;
    suspect: boolean | undefined;
}
```
also, 

* interface `CommunityAttributes` also contains `suspect: UbiCommunitySuspect[];`. When loading community info with `/community/publicid/:publicId` it only returns the most recent suspicious activity if it was less than two days ago.

* `/user/authentication` and `/user/hello` now requires `phone` with the user phone number. For `/user/hello` it's temporary, only to fill users info with require logout/login.