### PR TITLE
community organization data

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -31,6 +31,7 @@ import { Inflow } from '@models/ubi/inflow';
 import { Manager } from '@models/ubi/manager';
 import { UbiRequestChangeParamsModel } from '@models/ubi/requestChangeParams';
 import { UbiCommunitySuspectModel } from '@models/ubi/ubiCommunitySuspect';
+import { UbiOrganizationModel } from '@models/ubi/ubiOrganization';
 import { Logger } from '@utils/logger';
 import { Sequelize, Options, ModelCtor } from 'sequelize';
 
@@ -65,6 +66,8 @@ const models: DbModels = {
     community: sequelize.models.Community as ModelCtor<Community>,
     ubiCommunitySuspect: sequelize.models
         .UbiCommunitySuspectModel as ModelCtor<UbiCommunitySuspectModel>,
+    ubiOrganization: sequelize.models
+        .UbiOrganizationModel as ModelCtor<UbiOrganizationModel>,
     communityContract: sequelize.models
         .CommunityContract as ModelCtor<CommunityContract>,
     communityState: sequelize.models

--- a/src/database/migrations/z1616931369-create-ubiOrganization.js
+++ b/src/database/migrations/z1616931369-create-ubiOrganization.js
@@ -1,0 +1,35 @@
+'use strict';
+module.exports = {
+    up(queryInterface, Sequelize) {
+        return queryInterface.createTable('ubi_organization', {
+            id: {
+                type: Sequelize.INTEGER,
+                autoIncrement: true,
+                primaryKey: true,
+            },
+            name: {
+                type: Sequelize.STRING(64),
+                allowNull: false,
+            },
+            description: {
+                type: Sequelize.STRING(512),
+                allowNull: false,
+            },
+            logo: {
+                type: Sequelize.STRING(128),
+                allowNull: false,
+            },
+            website: {
+                type: Sequelize.STRING(128),
+                allowNull: false,
+            },
+            facebook: {
+                type: Sequelize.STRING(128),
+                allowNull: false,
+            },
+        });
+    },
+    down(queryInterface, Sequelize) {
+        return queryInterface.dropTable('ubi_organization');
+    },
+};

--- a/src/database/migrations/z1616931469-create-ubiCommunityOrganization.js
+++ b/src/database/migrations/z1616931469-create-ubiCommunityOrganization.js
@@ -2,7 +2,7 @@
 module.exports = {
     up(queryInterface, Sequelize) {
         return queryInterface.createTable('ubi_community_organization', {
-            id: {
+            organizationId: {
                 type: Sequelize.INTEGER,
                 references: {
                     model: 'ubi_organization',

--- a/src/database/migrations/z1616931469-create-ubiCommunityOrganization.js
+++ b/src/database/migrations/z1616931469-create-ubiCommunityOrganization.js
@@ -1,0 +1,28 @@
+'use strict';
+module.exports = {
+    up(queryInterface, Sequelize) {
+        return queryInterface.createTable('ubi_community_organization', {
+            id: {
+                type: Sequelize.INTEGER,
+                references: {
+                    model: 'ubi_organization',
+                    key: 'id',
+                },
+                onDelete: 'CASCADE',
+                allowNull: false,
+            },
+            communityId: {
+                type: Sequelize.INTEGER,
+                references: {
+                    model: 'community',
+                    key: 'id',
+                },
+                onDelete: 'CASCADE',
+                allowNull: false,
+            },
+        });
+    },
+    down(queryInterface, Sequelize) {
+        return queryInterface.dropTable('ubi_community_organization');
+    },
+};

--- a/src/database/models/associations/community.ts
+++ b/src/database/models/associations/community.ts
@@ -15,4 +15,14 @@ export function communityAssociation(sequelize: Sequelize) {
         sourceKey: 'publicId',
         as: 'beneficiaries',
     });
+
+    // used to query from the community with incude
+    // this should be a belongsTo instead, but we want to use a third table
+    sequelize.models.Community.belongsToMany(
+        sequelize.models.UbiOrganizationModel,
+        {
+            through: sequelize.models.UbiCommunityOrganizationModel,
+            as: 'organization',
+        }
+    );
 }

--- a/src/database/models/associations/community.ts
+++ b/src/database/models/associations/community.ts
@@ -22,6 +22,17 @@ export function communityAssociation(sequelize: Sequelize) {
         sequelize.models.UbiOrganizationModel,
         {
             through: sequelize.models.UbiCommunityOrganizationModel,
+            sourceKey: 'id',
+            foreignKey: 'communityId',
+            as: 'organization',
+        }
+    );
+    sequelize.models.UbiOrganizationModel.belongsToMany(
+        sequelize.models.Community,
+        {
+            through: sequelize.models.UbiCommunityOrganizationModel,
+            sourceKey: 'id',
+            foreignKey: 'organizationId',
             as: 'organization',
         }
     );

--- a/src/database/models/index.ts
+++ b/src/database/models/index.ts
@@ -38,7 +38,9 @@ import { initializeCommunityState } from './ubi/communityState';
 import { initializeInflow } from './ubi/inflow';
 import { initializeManager } from './ubi/manager';
 import { initializeUbiRequestChangeParams } from './ubi/requestChangeParams';
+import { initializeUbiCommunityOrganization } from './ubi/ubiCommunityOrganization';
 import { initializeUbiCommunitySuspect } from './ubi/ubiCommunitySuspect';
+import { initializeUbiOrganization } from './ubi/ubiOrganization';
 
 export default function initModels(sequelize: Sequelize): void {
     // app
@@ -68,6 +70,8 @@ export default function initModels(sequelize: Sequelize): void {
     initializeBeneficiaryTransaction(sequelize);
     initializeClaim(sequelize);
     initializeInflow(sequelize);
+    initializeUbiCommunityOrganization(sequelize);
+    initializeUbiOrganization(sequelize);
 
     // others
     initializeNotifiedBacker(sequelize);

--- a/src/database/models/ubi/community.ts
+++ b/src/database/models/ubi/community.ts
@@ -1,5 +1,6 @@
 import { StoryCommunity } from '@interfaces/story/storyCommunity';
 import { UbiCommunitySuspect } from '@interfaces/ubi/ubiCommunitySuspect';
+import { UbiOrganization } from '@interfaces/ubi/ubiOrganization';
 import { Sequelize, DataTypes, Model } from 'sequelize';
 
 import { ICommunityVars } from '../../../types';
@@ -35,6 +36,7 @@ export interface CommunityAttributes {
     storyCommunity?: StoryCommunity[];
     suspect?: UbiCommunitySuspect[];
     beneficiaries?: BeneficiaryAttributes[];
+    organization?: UbiOrganization;
 }
 export interface CommunityCreationAttributes {
     requestByAddress: string;

--- a/src/database/models/ubi/ubiCommunityOrganization.ts
+++ b/src/database/models/ubi/ubiCommunityOrganization.ts
@@ -1,0 +1,43 @@
+import {
+    UbiCommunityOrganization,
+    UbiCommunityOrganizationCreation,
+} from '@interfaces/ubi/ubiCommunityOrganization';
+import { Sequelize, DataTypes, Model } from 'sequelize';
+
+export class UbiCommunityOrganizationModel extends Model<
+    UbiCommunityOrganization,
+    UbiCommunityOrganizationCreation
+> {
+    public organizationId!: number;
+    public communityId!: number;
+}
+
+export function initializeUbiCommunityOrganization(sequelize: Sequelize): void {
+    UbiCommunityOrganizationModel.init(
+        {
+            organizationId: {
+                type: DataTypes.INTEGER,
+                references: {
+                    model: 'ubi_organization',
+                    key: 'id',
+                },
+                onDelete: 'CASCADE',
+                allowNull: false,
+            },
+            communityId: {
+                type: DataTypes.INTEGER,
+                references: {
+                    model: 'community',
+                    key: 'id',
+                },
+                onDelete: 'CASCADE',
+                allowNull: false,
+            },
+        },
+        {
+            tableName: 'ubi_community_organization',
+            timestamps: false,
+            sequelize,
+        }
+    );
+}

--- a/src/database/models/ubi/ubiOrganization.ts
+++ b/src/database/models/ubi/ubiOrganization.ts
@@ -1,0 +1,54 @@
+import {
+    UbiOrganization,
+    UbiOrganizationCreation,
+} from '@interfaces/ubi/ubiOrganization';
+import { Sequelize, DataTypes, Model } from 'sequelize';
+
+export class UbiOrganizationModel extends Model<
+    UbiOrganization,
+    UbiOrganizationCreation
+> {
+    public communityId!: string;
+    public name!: string;
+    public description!: string;
+    public logo!: string;
+    public website!: string;
+    public facebook!: string;
+}
+
+export function initializeUbiOrganization(sequelize: Sequelize): void {
+    UbiOrganizationModel.init(
+        {
+            id: {
+                type: DataTypes.INTEGER,
+                primaryKey: true,
+                unique: true,
+            },
+            name: {
+                type: DataTypes.STRING(64),
+                allowNull: false,
+            },
+            description: {
+                type: DataTypes.STRING(512),
+                allowNull: false,
+            },
+            logo: {
+                type: DataTypes.STRING(128),
+                allowNull: false,
+            },
+            website: {
+                type: DataTypes.STRING(128),
+                allowNull: false,
+            },
+            facebook: {
+                type: DataTypes.STRING(128),
+                allowNull: false,
+            },
+        },
+        {
+            tableName: 'ubi_organization',
+            timestamps: false,
+            sequelize,
+        }
+    );
+}

--- a/src/interfaces/ubi/ubiCommunityOrganization.ts
+++ b/src/interfaces/ubi/ubiCommunityOrganization.ts
@@ -1,0 +1,6 @@
+export interface UbiCommunityOrganization {
+    communityId: number;
+    organizationId: number;
+}
+
+export interface UbiCommunityOrganizationCreation {}

--- a/src/interfaces/ubi/ubiOrganization.ts
+++ b/src/interfaces/ubi/ubiOrganization.ts
@@ -1,0 +1,16 @@
+export interface UbiOrganization {
+    id: number;
+    name: string;
+    description: string;
+    logo: string;
+    website: string;
+    facebook: string;
+}
+
+export interface UbiOrganizationCreation {
+    name: string;
+    description: string;
+    logo: string;
+    website: string;
+    facebook: string;
+}

--- a/src/services/ubi/community.ts
+++ b/src/services/ubi/community.ts
@@ -39,6 +39,7 @@ export default class CommunityService {
     public static communityDailyMetrics = models.communityDailyMetrics;
     public static ubiRequestChangeParams = models.ubiRequestChangeParams;
     public static ubiCommunitySuspect = models.ubiCommunitySuspect;
+    public static ubiOrganization = models.ubiOrganization;
     public static sequelize = sequelize;
 
     public static async create(
@@ -743,6 +744,11 @@ export default class CommunityService {
                             ),
                         },
                     },
+                },
+                {
+                    model: this.ubiOrganization,
+                    as: 'organization',
+                    required: false,
                 },
             ],
             where: {

--- a/src/types/db.ts
+++ b/src/types/db.ts
@@ -31,6 +31,7 @@ import { Inflow } from '@models/ubi/inflow';
 import { Manager } from '@models/ubi/manager';
 import { UbiRequestChangeParamsModel } from '@models/ubi/requestChangeParams';
 import { UbiCommunitySuspectModel } from '@models/ubi/ubiCommunitySuspect';
+import { UbiOrganizationModel } from '@models/ubi/ubiOrganization';
 import { ModelCtor, Sequelize } from 'sequelize/types';
 
 export interface DbModels {
@@ -39,6 +40,7 @@ export interface DbModels {
     appUserThroughTrust: ModelCtor<AppUserThroughTrustModel>;
     community: ModelCtor<Community>;
     ubiCommunitySuspect: ModelCtor<UbiCommunitySuspectModel>;
+    ubiOrganization: ModelCtor<UbiOrganizationModel>;
     communityContract: ModelCtor<CommunityContract>;
     communityState: ModelCtor<CommunityState>;
     communityDailyState: ModelCtor<CommunityDailyState>;


### PR DESCRIPTION
does not add a new endpoint, instead, extends existing ones

`CommunityAttributes` now has `organization?: UbiOrganization;` which is

```javascript
interface UbiOrganizationCreation {
    name: string;
    description: string;
    logo: string;
    website: string;
    facebook: string;
}