### PR TITLE
break community endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
         "@typescript-eslint/eslint-plugin": "3.4.0",
         "@typescript-eslint/parser": "3.4.0",
         "chai": "4.2.0",
+        "chai-http": "4.3.0",
         "coveralls": "3.1.0",
         "eslint": "7.3.1",
         "eslint-config-prettier": "6.11.0",

--- a/src/api/app.ts
+++ b/src/api/app.ts
@@ -8,45 +8,47 @@ import config from '../config';
 import { sequelize } from '../database';
 import serverLoader from './server';
 
-async function startServer() {
+export async function startServer() {
     const app = express();
 
-    Sentry.init({
-        dsn: config.sentryKey,
-        debug: process.env.NODE_ENV === 'development',
-        integrations: [
-            // enable HTTP calls tracing
-            new Sentry.Integrations.Http({ tracing: true }),
-            // enable Express.js middleware tracing
-            new Integrations.Express({ app }),
-        ],
-        tracesSampler: (samplingContext) => {
-            // Examine provided context data (including parent decision, if any) along
-            // with anything in the global namespace to compute the sample rate or
-            // sampling decision for this transaction
+    if (process.env.NODE_ENV !== 'test') {
+        Sentry.init({
+            dsn: config.sentryKey,
+            debug: process.env.NODE_ENV === 'development',
+            integrations: [
+                // enable HTTP calls tracing
+                new Sentry.Integrations.Http({ tracing: true }),
+                // enable Express.js middleware tracing
+                new Integrations.Express({ app }),
+            ],
+            tracesSampler: (samplingContext) => {
+                // Examine provided context data (including parent decision, if any) along
+                // with anything in the global namespace to compute the sample rate or
+                // sampling decision for this transaction
 
-            // always inherit
-            if (samplingContext.parentSampled !== undefined) {
-                return samplingContext.parentSampled;
-            }
+                // always inherit
+                if (samplingContext.parentSampled !== undefined) {
+                    return samplingContext.parentSampled;
+                }
 
-            if (
-                samplingContext.transactionContext.name.indexOf(
-                    '/mobile/error'
-                ) !== -1 ||
-                samplingContext.transactionContext.name.indexOf(
-                    '/mobile/version'
-                ) !== -1
-            ) {
-                // Ignore this.
-                return 0;
-            } else {
-                // Default sample rate
-                return config.tracesSampleRate;
-            }
-        },
-        tracesSampleRate: config.tracesSampleRate,
-    });
+                if (
+                    samplingContext.transactionContext.name.indexOf(
+                        '/mobile/error'
+                    ) !== -1 ||
+                    samplingContext.transactionContext.name.indexOf(
+                        '/mobile/version'
+                    ) !== -1
+                ) {
+                    // Ignore this.
+                    return 0;
+                } else {
+                    // Default sample rate
+                    return config.tracesSampleRate;
+                }
+            },
+            tracesSampleRate: config.tracesSampleRate,
+        });
+    }
 
     if (process.env.NODE_ENV === 'development') {
         Logger.debug('DEBUG');
@@ -57,13 +59,15 @@ async function startServer() {
     }
 
     await sequelize.authenticate();
-    await sequelize.sync();
+    if (process.env.NODE_ENV !== 'test') {
+        await sequelize.sync();
+    }
     Logger.info('🗺️  Database loaded and connected');
 
     await serverLoader(app);
     Logger.info('📡 Express server loaded');
 
-    app.listen(config.port, () => {
+    return app.listen(config.port, () => {
         Logger.info(`
         ################################################
         🛡️  Server listening on port: ${config.port} 🛡️ 
@@ -72,4 +76,6 @@ async function startServer() {
     });
 }
 
-startServer();
+if (process.env.NODE_ENV !== 'test') {
+    startServer();
+}

--- a/src/api/controllers/community.ts
+++ b/src/api/controllers/community.ts
@@ -109,7 +109,37 @@ class CommunityController {
     };
 
     getManagers = (req: Request, res: Response) => {
-        CommunityService.getManagers(req.params.id)
+        CommunityService.getManagers(parseInt(req.params.id, 10))
+            .then((r) => standardResponse(res, 200, true, r))
+            .catch((e) => standardResponse(res, 400, false, '', { error: e }));
+    };
+
+    getPromoter = (req: Request, res: Response) => {
+        CommunityService.getPromoter(parseInt(req.params.id, 10))
+            .then((r) => standardResponse(res, 200, true, r))
+            .catch((e) => standardResponse(res, 400, false, '', { error: e }));
+    };
+
+    getSuspect = (req: Request, res: Response) => {
+        CommunityService.getSuspect(parseInt(req.params.id, 10))
+            .then((r) => standardResponse(res, 200, true, r))
+            .catch((e) => standardResponse(res, 400, false, '', { error: e }));
+    };
+
+    getContract = (req: Request, res: Response) => {
+        CommunityService.getContract(parseInt(req.params.id, 10))
+            .then((r) => standardResponse(res, 200, true, r))
+            .catch((e) => standardResponse(res, 400, false, '', { error: e }));
+    };
+
+    getState = (req: Request, res: Response) => {
+        CommunityService.getState(parseInt(req.params.id, 10))
+            .then((r) => standardResponse(res, 200, true, r))
+            .catch((e) => standardResponse(res, 400, false, '', { error: e }));
+    };
+
+    getMetrics = (req: Request, res: Response) => {
+        CommunityService.getMetrics(parseInt(req.params.id, 10))
             .then((r) => standardResponse(res, 200, true, r))
             .catch((e) => standardResponse(res, 400, false, '', { error: e }));
     };
@@ -373,7 +403,7 @@ const getClaimLocation = (req: Request, res: Response) => {
 };
 
 const getManagers = (req: Request, res: Response) => {
-    CommunityService.getManagers(req.params.id)
+    CommunityService.getManagers(parseInt(req.params.id, 10))
         .then((r) => standardResponse(res, 200, true, r))
         .catch((e) => controllerLogAndFail(e, 400, res));
 };

--- a/src/api/routes/community.ts
+++ b/src/api/routes/community.ts
@@ -404,6 +404,76 @@ export default (app: Router): void => {
     /**
      * @swagger
      *
+     * /community/{id}/promoter:
+     *   get:
+     *     tags:
+     *       - "community"
+     *     summary: Get community promoter
+     *     responses:
+     *       "200":
+     *         description: OK
+     */
+    route.get('/:id/promoter', controller.getPromoter);
+
+    /**
+     * @swagger
+     *
+     * /community/{id}/suspect:
+     *   get:
+     *     tags:
+     *       - "community"
+     *     summary: Get suspicious community activity
+     *     responses:
+     *       "200":
+     *         description: OK
+     */
+    route.get('/:id/suspect', controller.getSuspect);
+
+    /**
+     * @swagger
+     *
+     * /community/{id}/contract:
+     *   get:
+     *     tags:
+     *       - "community"
+     *     summary: Get community contract UBI parameters
+     *     responses:
+     *       "200":
+     *         description: OK
+     */
+    route.get('/:id/contract', controller.getContract);
+
+    /**
+     * @swagger
+     *
+     * /community/{id}/state:
+     *   get:
+     *     tags:
+     *       - "community"
+     *     summary: Get community state
+     *     responses:
+     *       "200":
+     *         description: OK
+     */
+    route.get('/:id/state', controller.getState);
+
+    /**
+     * @swagger
+     *
+     * /community/{id}/metrics:
+     *   get:
+     *     tags:
+     *       - "community"
+     *     summary: Get community metrics
+     *     responses:
+     *       "200":
+     *         description: OK
+     */
+    route.get('/:id/metrics', controller.getMetrics);
+
+    /**
+     * @swagger
+     *
      * /community/{id}:
      *   get:
      *     tags:

--- a/src/api/routes/community.ts
+++ b/src/api/routes/community.ts
@@ -486,6 +486,10 @@ export default (app: Router): void => {
      *     responses:
      *       "200":
      *         description: OK
+     *         content:
+     *           application/json:
+     *             schema:
+     *               $ref: '#/components/schemas/UbiCommunityContract'
      */
     route.get('/:id/contract', controller.getContract);
 

--- a/src/api/routes/community.ts
+++ b/src/api/routes/community.ts
@@ -299,9 +299,6 @@ export default (app: Router): void => {
      *     responses:
      *       "200":
      *         description: OK
-     *     security:
-     *     - api_auth:
-     *       - "read:modify":
      */
     route.get('/list/:query?', cacheWithRedis('10 minutes'), controller.list);
 
@@ -341,6 +338,13 @@ export default (app: Router): void => {
      *     tags:
      *       - "community"
      *     summary: Historical SSI
+     *     parameters:
+     *       - in: path
+     *         name: id
+     *         schema:
+     *           type: integer
+     *         required: true
+     *         description: community id
      *     responses:
      *       "200":
      *         description: OK
@@ -359,6 +363,13 @@ export default (app: Router): void => {
      *     tags:
      *       - "community"
      *     summary: Get community dashboard details
+     *     parameters:
+     *       - in: path
+     *         name: id
+     *         schema:
+     *           type: integer
+     *         required: true
+     *         description: community id
      *     responses:
      *       "200":
      *         description: OK
@@ -377,6 +388,13 @@ export default (app: Router): void => {
      *     tags:
      *       - "community"
      *     summary: Get community claim locations
+     *     parameters:
+     *       - in: path
+     *         name: id
+     *         schema:
+     *           type: integer
+     *         required: true
+     *         description: community id
      *     responses:
      *       "200":
      *         description: OK
@@ -395,6 +413,13 @@ export default (app: Router): void => {
      *     tags:
      *       - "community"
      *     summary: Get community managers
+     *     parameters:
+     *       - in: path
+     *         name: id
+     *         schema:
+     *           type: integer
+     *         required: true
+     *         description: community id
      *     responses:
      *       "200":
      *         description: OK
@@ -409,6 +434,13 @@ export default (app: Router): void => {
      *     tags:
      *       - "community"
      *     summary: Get community promoter
+     *     parameters:
+     *       - in: path
+     *         name: id
+     *         schema:
+     *           type: integer
+     *         required: true
+     *         description: community id
      *     responses:
      *       "200":
      *         description: OK
@@ -423,6 +455,13 @@ export default (app: Router): void => {
      *     tags:
      *       - "community"
      *     summary: Get suspicious community activity
+     *     parameters:
+     *       - in: path
+     *         name: id
+     *         schema:
+     *           type: integer
+     *         required: true
+     *         description: community id
      *     responses:
      *       "200":
      *         description: OK
@@ -437,6 +476,13 @@ export default (app: Router): void => {
      *     tags:
      *       - "community"
      *     summary: Get community contract UBI parameters
+     *     parameters:
+     *       - in: path
+     *         name: id
+     *         schema:
+     *           type: integer
+     *         required: true
+     *         description: community id
      *     responses:
      *       "200":
      *         description: OK
@@ -451,6 +497,13 @@ export default (app: Router): void => {
      *     tags:
      *       - "community"
      *     summary: Get community state
+     *     parameters:
+     *       - in: path
+     *         name: id
+     *         schema:
+     *           type: integer
+     *         required: true
+     *         description: community id
      *     responses:
      *       "200":
      *         description: OK
@@ -465,6 +518,13 @@ export default (app: Router): void => {
      *     tags:
      *       - "community"
      *     summary: Get community metrics
+     *     parameters:
+     *       - in: path
+     *         name: id
+     *         schema:
+     *           type: integer
+     *         required: true
+     *         description: community id
      *     responses:
      *       "200":
      *         description: OK

--- a/src/api/routes/community.ts
+++ b/src/api/routes/community.ts
@@ -444,6 +444,10 @@ export default (app: Router): void => {
      *     responses:
      *       "200":
      *         description: OK
+     *         content:
+     *           application/json:
+     *             schema:
+     *               $ref: '#/components/schemas/UbiPromoter'
      */
     route.get('/:id/promoter', controller.getPromoter);
 
@@ -465,6 +469,10 @@ export default (app: Router): void => {
      *     responses:
      *       "200":
      *         description: OK
+     *         content:
+     *           application/json:
+     *             schema:
+     *               $ref: '#/components/schemas/UbiCommunitySuspect'
      */
     route.get('/:id/suspect', controller.getSuspect);
 
@@ -511,6 +519,10 @@ export default (app: Router): void => {
      *     responses:
      *       "200":
      *         description: OK
+     *         content:
+     *           application/json:
+     *             schema:
+     *               $ref: '#/components/schemas/UbiCommunityState'
      */
     route.get('/:id/state', controller.getState);
 
@@ -532,6 +544,10 @@ export default (app: Router): void => {
      *     responses:
      *       "200":
      *         description: OK
+     *         content:
+     *           application/json:
+     *             schema:
+     *               $ref: '#/components/schemas/UbiCommunityDailyMetrics'
      */
     route.get('/:id/metrics', controller.getMetrics);
 

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/node';
 import { Logger } from '@utils/logger';
-import bodyParser from 'body-parser';
+// import bodyParser from 'body-parser';
 import cors from 'cors';
 import express, { Request, Response } from 'express';
 import helmet from 'helmet';
@@ -60,7 +60,7 @@ export default (app: express.Application): void => {
         ];
         urlSchema = 'https';
     }
-    if (swaggerServers.length > 0) {
+    if (swaggerServers.length > 0 && process.env.NODE_ENV !== 'test') {
         const options = {
             swaggerDefinition: {
                 openapi: '3.0.1',
@@ -132,7 +132,8 @@ export default (app: express.Application): void => {
     });
 
     // Middleware that transforms the raw string of req.body into json
-    app.use(bodyParser.json());
+    app.use(express.json());
+    // app.use(express.urlencoded({ extended: true }));
     // Load API routes
     app.use(config.api.prefix, routes());
 

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -103,7 +103,7 @@ export default (app: express.Application): void => {
                     },
                 },
             },
-            apis: ['./src/api/routes/*.ts', './src/database/models/ubi/*.ts'],
+            apis: ['./src/api/routes/*.ts', './src/interfaces/ubi/*.ts'],
         };
         const swaggerSpec = swaggerJsdoc(options);
 

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -103,7 +103,7 @@ export default (app: express.Application): void => {
                     },
                 },
             },
-            apis: ['./src/api/routes/*.ts'],
+            apis: ['./src/api/routes/*.ts', './src/database/models/ubi/*.ts'],
         };
         const swaggerSpec = swaggerJsdoc(options);
 

--- a/src/config/validatenv.ts
+++ b/src/config/validatenv.ts
@@ -48,7 +48,7 @@ function validateEnv() {
         MASTER_KEY: str({ devDefault: onlyOnTestEnv('xyz') }),
         LATEST_MOBILE_APP_VERSION: str({ devDefault: onlyOnTestEnv('0.0.0') }),
         MINIMAL_MOBILE_APP_VERSION: str({ devDefault: onlyOnTestEnv('0.0.1') }),
-        LOG_LEVEL: str({ default: 'verbose' }),
+        LOG_LEVEL: str({ default: 'warn' }),
         FLEEK_STORAGE_KEY_ID: str({ devDefault: onlyOnTestEnv('xyz') }),
         FLEEK_STORAGE_ACCESS_KEY: str({ devDefault: onlyOnTestEnv('xyz') }),
         COMMUNITY_PLACEHOLDER_IMAGE_URL: str({

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -144,9 +144,14 @@ const models: DbModels = {
         .StoryUserReportModel as ModelCtor<StoryUserReportModel>,
 };
 
-const redisClient = redis.createClient({
-    url: config.redis,
-});
-const cacheWithRedis = apicache.options({ redisClient }).middleware;
+const cacheWithRedis = apicache.options(
+    process.env.NODE_ENV === 'test'
+        ? {}
+        : {
+              redisClient: redis.createClient({
+                  url: config.redis,
+              }),
+          }
+).middleware;
 
-export { sequelize, Sequelize, models, redisClient, cacheWithRedis };
+export { sequelize, Sequelize, models, cacheWithRedis };

--- a/src/database/models/associations/community.ts
+++ b/src/database/models/associations/community.ts
@@ -91,15 +91,15 @@ export function communityAssociation(sequelize: Sequelize) {
 
     // used to query from the community with incude
     // this should be a belongsTo instead, but we want to use a third table
-    sequelize.models.Community.belongsToMany(
-        sequelize.models.UbiPromoterModel,
-        {
-            through: sequelize.models.UbiCommunityPromoterModel,
-            sourceKey: 'id',
-            foreignKey: 'communityId',
-            as: 'promoter',
-        }
-    );
+    // sequelize.models.Community.belongsToMany(
+    //     sequelize.models.UbiPromoterModel,
+    //     {
+    //         through: sequelize.models.UbiCommunityPromoterModel,
+    //         sourceKey: 'id',
+    //         foreignKey: 'communityId',
+    //         as: 'promoter',
+    //     }
+    // );
     sequelize.models.UbiPromoterModel.belongsToMany(
         sequelize.models.Community,
         {

--- a/src/database/models/associations/community.ts
+++ b/src/database/models/associations/community.ts
@@ -89,17 +89,7 @@ export function communityAssociation(sequelize: Sequelize) {
         as: 'beneficiaries',
     });
 
-    // used to query from the community with incude
-    // this should be a belongsTo instead, but we want to use a third table
-    // sequelize.models.Community.belongsToMany(
-    //     sequelize.models.UbiPromoterModel,
-    //     {
-    //         through: sequelize.models.UbiCommunityPromoterModel,
-    //         sourceKey: 'id',
-    //         foreignKey: 'communityId',
-    //         as: 'promoter',
-    //     }
-    // );
+    // used to query from the promoter with incude
     sequelize.models.UbiPromoterModel.belongsToMany(
         sequelize.models.Community,
         {

--- a/src/database/models/ubi/community.ts
+++ b/src/database/models/ubi/community.ts
@@ -46,7 +46,7 @@ export interface CommunityAttributes {
     storyCommunity?: StoryCommunity[];
     suspect?: UbiCommunitySuspect[];
     beneficiaries?: BeneficiaryAttributes[];
-    promoter?: UbiPromoter;
+    // promoter?: UbiPromoter;
     claimLocation?: ClaimLocationAttributes[];
     demographics?: UbiCommunityDemographics[];
     dailyState?: UbiCommunityDailyState[];

--- a/src/database/models/ubi/community.ts
+++ b/src/database/models/ubi/community.ts
@@ -6,7 +6,7 @@ import { UbiCommunityDailyState } from '@interfaces/ubi/ubiCommunityDailyState';
 import { UbiCommunityDemographics } from '@interfaces/ubi/ubiCommunityDemographics';
 import { UbiCommunityState } from '@interfaces/ubi/ubiCommunityState';
 import { UbiCommunitySuspect } from '@interfaces/ubi/ubiCommunitySuspect';
-import { UbiPromoter } from '@interfaces/ubi/ubiPromoter';
+// import { UbiPromoter } from '@interfaces/ubi/ubiPromoter';
 import { Sequelize, DataTypes, Model } from 'sequelize';
 
 import { BeneficiaryAttributes } from './beneficiary';
@@ -14,7 +14,7 @@ import { ClaimLocationAttributes } from './claimLocation';
 
 export interface CommunityAttributes {
     id: number; // Note that the `null assertion` `!` is required in strict mode.
-    publicId: string;
+    publicId: string; // TODO: to be removed
     requestByAddress: string;
     contractAddress: string | null;
     name: string;
@@ -30,26 +30,26 @@ export interface CommunityAttributes {
     };
     email: string;
     visibility: 'public' | 'private';
-    coverImage: string;
+    coverImage: string; // TODO: to be removed
     coverMediaId: number;
     status: 'pending' | 'valid' | 'removed'; // pending / valid / removed
-    started: Date;
+    started: Date; // TODO: to be removed
 
     // timestamps
     createdAt: Date;
     updatedAt: Date;
 
-    metrics?: UbiCommunityDailyMetrics[];
+    metrics?: UbiCommunityDailyMetrics[]; // TODO: to be removed
     cover?: AppMediaContent;
-    contract?: UbiCommunityContract;
-    state?: UbiCommunityState;
-    storyCommunity?: StoryCommunity[];
-    suspect?: UbiCommunitySuspect[];
-    beneficiaries?: BeneficiaryAttributes[];
+    contract?: UbiCommunityContract; // TODO: to be removed
+    state?: UbiCommunityState; // TODO: to be removed
+    storyCommunity?: StoryCommunity[]; // TODO: to be removed
+    suspect?: UbiCommunitySuspect[]; // TODO: to be removed
+    beneficiaries?: BeneficiaryAttributes[]; // TODO: to be removed
     // promoter?: UbiPromoter;
-    claimLocation?: ClaimLocationAttributes[];
-    demographics?: UbiCommunityDemographics[];
-    dailyState?: UbiCommunityDailyState[];
+    claimLocation?: ClaimLocationAttributes[]; // TODO: to be removed
+    demographics?: UbiCommunityDemographics[]; // TODO: to be removed
+    dailyState?: UbiCommunityDailyState[]; // TODO: to be removed
 }
 export interface CommunityCreationAttributes {
     requestByAddress: string;

--- a/src/database/models/ubi/communityContract.ts
+++ b/src/database/models/ubi/communityContract.ts
@@ -4,6 +4,35 @@ import {
 } from '@interfaces/ubi/ubiCommunityContract';
 import { Sequelize, DataTypes, Model } from 'sequelize';
 
+/**
+ * @swagger
+ *  components:
+ *    schemas:
+ *      UbiCommunityContract:
+ *        type: object
+ *        required:
+ *          - communityId
+ *          - claimAmount
+ *          - maxClaim
+ *          - baseInterval
+ *          - incrementInterval
+ *        properties:
+ *          communityId:
+ *            type: integer
+ *            description: The community id
+ *          claimAmount:
+ *            type: string
+ *            description: Amount per claim, same as in contract with 18 decimals
+ *          maxClaim:
+ *            type: string
+ *            description: Maximum claim per beneficiary, same as in contract with 18 decimals
+ *          baseInterval:
+ *            type: integer
+ *            description: Base interval between claims
+ *          incrementInterval:
+ *            type: integer
+ *            description: Increment interval after each claim
+ */
 export class UbiCommunityContractModel extends Model<
     UbiCommunityContract,
     UbiCommunityContractCreation

--- a/src/interfaces/ubi/ubiCommunityDailyMetrics.ts
+++ b/src/interfaces/ubi/ubiCommunityDailyMetrics.ts
@@ -1,3 +1,37 @@
+/**
+ * @swagger
+ *  components:
+ *    schemas:
+ *      UbiCommunityDailyMetrics:
+ *        type: object
+ *        required:
+ *          - communityId
+ *          - ssiDayAlone
+ *          - ssi
+ *          - ubiRate
+ *          - estimatedDuration
+ *          - date
+ *        properties:
+ *          communityId:
+ *            type: integer
+ *            description: The community id
+ *          ssiDayAlone:
+ *            type: integer
+ *            description: SSI (without 5 days average)
+ *          ssi:
+ *            type: integer
+ *            description: SSI (with 5 days average)
+ *          ubiRate:
+ *            type: integer
+ *            description: UBI rate per beneficiary
+ *          estimatedDuration:
+ *            type: integer
+ *            description: Estimated duration of the UBI program
+ *          date:
+ *            type: string
+ *            format: date
+ *            description: Date of which the daily metrics represents
+ */
 export interface UbiCommunityDailyMetrics {
     id: number;
     communityId: number;

--- a/src/interfaces/ubi/ubiCommunityState.ts
+++ b/src/interfaces/ubi/ubiCommunityState.ts
@@ -1,3 +1,44 @@
+/**
+ * @swagger
+ *  components:
+ *    schemas:
+ *      UbiCommunityState:
+ *        type: object
+ *        required:
+ *          - communityId
+ *          - claimed
+ *          - claims
+ *          - beneficiaries
+ *          - removedBeneficiaries
+ *          - managers
+ *          - raised
+ *          - backers
+ *        properties:
+ *          communityId:
+ *            type: integer
+ *            description: The community id
+ *          claimed:
+ *            type: string
+ *            description: Claimed amount since contract inception (with 18 decimals)
+ *          claims:
+ *            type: integer
+ *            description: Number of claims since contract inception
+ *          beneficiaries:
+ *            type: integer
+ *            description: Number of currently active beneficiaries
+ *          removedBeneficiaries:
+ *            type: integer
+ *            description: Number of currently removed beneficiaries
+ *          managers:
+ *            type: integer
+ *            description: Number of current active managers
+ *          raised:
+ *            type: string
+ *            description: Raised amount since contract inception (with 18 decimals)
+ *          backers:
+ *            type: integer
+ *            description: Number of unique backers since contract inception
+ */
 export interface UbiCommunityState {
     communityId: number;
     claimed: string;

--- a/src/interfaces/ubi/ubiCommunitySuspect.ts
+++ b/src/interfaces/ubi/ubiCommunitySuspect.ts
@@ -1,3 +1,29 @@
+/**
+ * @swagger
+ *  components:
+ *    schemas:
+ *      UbiCommunitySuspect:
+ *        type: object
+ *        required:
+ *          - communityId
+ *          - percentage
+ *          - suspect
+ *          - createdAt
+ *        properties:
+ *          communityId:
+ *            type: integer
+ *            description: The community id
+ *          percentage:
+ *            type: number
+ *            description: Percentage of beneficiaries with suspect activity
+ *          suspect:
+ *            type: number
+ *            description: Suspect level (from 1 to 10), non-linear. 10 is more that 45% beneficiaries are suspect
+ *          createdAt:
+ *            type: string
+ *            format: date-time
+ *            description: Date of when the registry for suspect activity was created
+ */
 export interface UbiCommunitySuspect {
     id: number;
     communityId: number;

--- a/src/interfaces/ubi/ubiPromoter.ts
+++ b/src/interfaces/ubi/ubiPromoter.ts
@@ -2,6 +2,29 @@ import { AppMediaContent } from '@interfaces/app/appMediaContent';
 
 import { UbiPromoterSocialMedia } from './ubiPromoterSocialMedia';
 
+/**
+ * @swagger
+ *  components:
+ *    schemas:
+ *      UbiPromoter:
+ *        type: object
+ *        required:
+ *          - category
+ *          - name
+ *          - description
+ *        properties:
+ *          category:
+ *            type: string
+ *            description: Promoter gategory
+ *          name:
+ *            type: string
+ *            description: Promoter name
+ *          description:
+ *            type: string
+ *            description: Promoter description
+ *          socialMedia:
+ *            $ref: '#/components/schemas/UbiPromoterSocialMedia'
+ */
 export interface UbiPromoter {
     id: number;
     category: 'organization' | 'company' | 'individual';

--- a/src/interfaces/ubi/ubiPromoterSocialMedia.ts
+++ b/src/interfaces/ubi/ubiPromoterSocialMedia.ts
@@ -1,3 +1,24 @@
+/**
+ * @swagger
+ *  components:
+ *    schemas:
+ *      UbiPromoterSocialMedia:
+ *        type: object
+ *        required:
+ *          - promoterId
+ *          - mediaType
+ *          - url
+ *        properties:
+ *          promoterId:
+ *            type: integer
+ *            description: Promoter id
+ *          mediaType:
+ *            type: string
+ *            description: Promoter media (usually social network name)
+ *          url:
+ *            type: string
+ *            description: Promoter media URL
+ */
 export interface UbiPromoterSocialMedia {
     id: number;
     promoterId: number;

--- a/src/services/app/exchangeRates.ts
+++ b/src/services/app/exchangeRates.ts
@@ -1,8 +1,10 @@
 import { ExchangeRatesAttributes } from '@models/app/exchangeRates';
+import redis from 'redis';
 import { promisify } from 'util';
 
-import { models, redisClient } from '../../database';
-const getRedis = promisify(redisClient.get).bind(redisClient);
+import config from '../../config';
+import { models } from '../../database';
+
 // const setRedis = promisify(redisClient.set);
 
 export default class ExchangeRatesService {
@@ -10,21 +12,31 @@ export default class ExchangeRatesService {
     private static redisKey = 'exchangeRates';
 
     public static async get(): Promise<ExchangeRatesAttributes[]> {
-        const rates = await getRedis(this.redisKey);
-        if (rates === null) {
-            const currentRates = await this.exchangeRates.findAll({
-                attributes: ['currency', 'rate'],
-                raw: true,
+        if (process.env.NODE_ENV !== 'test') {
+            const redisClient = redis.createClient({
+                url: config.redis,
             });
-            redisClient.set(
-                this.redisKey,
-                JSON.stringify(currentRates),
-                'EX',
-                21600 // 6 hours in seconds
-            );
+            const getRedis = promisify(redisClient.get).bind(redisClient);
+            const rates = await getRedis(this.redisKey);
+            if (rates === null) {
+                const currentRates = await this.exchangeRates.findAll({
+                    attributes: ['currency', 'rate'],
+                    raw: true,
+                });
+                redisClient.set(
+                    this.redisKey,
+                    JSON.stringify(currentRates),
+                    'EX',
+                    21600 // 6 hours in seconds
+                );
 
-            return currentRates;
+                return currentRates;
+            }
+            return JSON.parse(rates);
         }
-        return JSON.parse(rates);
+        return this.exchangeRates.findAll({
+            attributes: ['currency', 'rate'],
+            raw: true,
+        });
     }
 }

--- a/src/services/ubi/community.ts
+++ b/src/services/ubi/community.ts
@@ -1252,27 +1252,6 @@ export default class CommunityService {
                         },
                     },
                 },
-                // {
-                //     model: this.ubiPromoter,
-                //     as: 'promoter',
-                //     required: false,
-                //     include: [
-                //         {
-                //             model: this.ubiPromoterSocialMedia,
-                //             as: 'socialMedia',
-                //         },
-                //         {
-                //             model: this.appMediaContent,
-                //             as: 'logo',
-                //             include: [
-                //                 {
-                //                     model: this.appMediaThumbnail,
-                //                     as: 'thumbnails',
-                //                 },
-                //             ],
-                //         },
-                //     ],
-                // },
                 {
                     model: this.appMediaContent,
                     as: 'cover',

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,41 +1,12 @@
-import winston from 'winston';
+import winston, { format } from 'winston';
 
 import config from '../config';
 
-const transports: (
-    | winston.transports.FileTransportInstance
-    | winston.transports.ConsoleTransportInstance
-)[] = [
-    // new winston.transports.File({ filename: 'error.log', level: 'error' }),
-    // new winston.transports.File({ filename: 'combined.log' }),
-    new winston.transports.Console({
-        format: winston.format.combine(
-            winston.format.cli(),
-            winston.format.splat()
-        ),
-    }),
-];
-// if (NODE_ENV === 'development') {
-//     transports.push(
-//         new winston.transports.Console({
-//             format: winston.format.combine(
-//                 winston.format.cli(),
-//                 winston.format.splat(),
-//             )
-//         })
-//     )
-// }
-
 export const Logger = winston.createLogger({
     level: config.logs.level,
-    levels: winston.config.npm.levels,
-    format: winston.format.combine(
-        winston.format.timestamp({
-            format: 'DD-MM-YYYY HH:mm:ss',
+    transports: [
+        new winston.transports.Console({
+            format: format.combine(format.cli(), format.splat()),
         }),
-        winston.format.errors({ stack: true }),
-        winston.format.splat(),
-        winston.format.json()
-    ),
-    transports,
+    ],
 });

--- a/tests/endpoints/community.test.ts
+++ b/tests/endpoints/community.test.ts
@@ -1,25 +1,25 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+// import chai, { expect } from 'chai';
+// import chaiHttp from 'chai-http';
 
-import { startServer } from '../../src/api/app';
+// import { startServer } from '../../src/api/app';
 
-chai.use(chaiHttp);
+// chai.use(chaiHttp);
 
-describe('community API request', () => {
-    let requester: ChaiHttp.Agent;
+// describe('community API request', () => {
+//     let requester: ChaiHttp.Agent;
 
-    before(async () => {
-        requester = chai.request(await startServer()).keepOpen();
-    });
+//     before(async () => {
+//         requester = chai.request(await startServer()).keepOpen();
+//     });
 
-    after(async () => {
-        await requester.close();
-    });
+//     after(async () => {
+//         await requester.close();
+//     });
 
-    it('verify /status', async () => {
-        const res = await requester.get('/status');
-        expect(res).to.have.status(200);
-        // eslint-disable-next-line no-unused-expressions
-        expect(res.body).to.be.empty;
-    });
-});
+//     it('verify /status', async () => {
+//         const res = await requester.get('/status');
+//         expect(res).to.have.status(200);
+//         // eslint-disable-next-line no-unused-expressions
+//         expect(res.body).to.be.empty;
+//     });
+// });

--- a/tests/endpoints/community.test.ts
+++ b/tests/endpoints/community.test.ts
@@ -1,0 +1,25 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+
+import { startServer } from '../../src/api/app';
+
+chai.use(chaiHttp);
+
+describe('community API request', () => {
+    let requester: ChaiHttp.Agent;
+
+    before(async () => {
+        requester = chai.request(await startServer()).keepOpen();
+    });
+
+    after(async () => {
+        await requester.close();
+    });
+
+    it('verify /status', async () => {
+        const res = await requester.get('/status');
+        expect(res).to.have.status(200);
+        // eslint-disable-next-line no-unused-expressions
+        expect(res.body).to.be.empty;
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1058,6 +1058,11 @@
     "@types/connect" "*"
     "@types/node" "*"
 
+"@types/chai@4":
+  version "4.2.18"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.18.tgz#0c8e298dbff8205e2266606c1ea5fbdba29b46e4"
+  integrity sha512-rS27+EkB/RE1Iz3u0XtVL5q36MGDWbgYe7zWiodyKNUnthxY0rukK5V36eiUCtCisB7NN8zKYH6DO2M37qxFEQ==
+
 "@types/chai@4.2.14":
   version "4.2.14"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.14.tgz#44d2dd0b5de6185089375d976b4ec5caf6861193"
@@ -1069,6 +1074,11 @@
   integrity sha512-ePPA/JuI+X0vb+gSWlPKOY0NdNAie/rPUqX2GUPpbZwiKTkSPhjXWuee47E4MtE54QVzGCQMQkAL6JhV2E1+cQ==
   dependencies:
     "@types/node" "*"
+
+"@types/cookiejar@*":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@types/cookiejar/-/cookiejar-2.1.2.tgz#66ad9331f63fe8a3d3d9d8c6e3906dd10f6446e8"
+  integrity sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==
 
 "@types/cors@2.8.6":
   version "2.8.6"
@@ -1283,6 +1293,14 @@
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz#3a84cf5ec3249439015e14049bd3161419bf9eae"
   integrity sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg==
+
+"@types/superagent@^3.8.3":
+  version "3.8.7"
+  resolved "https://registry.yarnpkg.com/@types/superagent/-/superagent-3.8.7.tgz#1f1ed44634d5459b3a672eb7235a8e7cfd97704c"
+  integrity sha512-9KhCkyXv268A2nZ1Wvu7rQWM+BmdYUVkycFeNnYrUL5Zwu7o8wPQ3wBfW59dDP+wuoxw0ww8YKgTNv8j/cgscA==
+  dependencies:
+    "@types/cookiejar" "*"
+    "@types/node" "*"
 
 "@types/validator@13.0.0":
   version "13.0.0"
@@ -2006,6 +2024,19 @@ celebrate@14.0.0:
     joi "17.x.x"
     lodash "4.17.x"
 
+chai-http@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/chai-http/-/chai-http-4.3.0.tgz#3c37c675c1f4fe685185a307e345de7599337c1a"
+  integrity sha512-zFTxlN7HLMv+7+SPXZdkd5wUlK+KxH6Q7bIEMiEx0FK3zuuMqL7cwICAQ0V1+yYRozBburYuxN1qZstgHpFZQg==
+  dependencies:
+    "@types/chai" "4"
+    "@types/superagent" "^3.8.3"
+    cookiejar "^2.1.1"
+    is-ip "^2.0.0"
+    methods "^1.1.2"
+    qs "^6.5.1"
+    superagent "^3.7.0"
+
 chai@4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.2.0.tgz#760aa72cf20e3795e84b12877ce0e83737aa29e5"
@@ -2251,6 +2282,11 @@ complex.js@^2.0.11:
   resolved "https://registry.yarnpkg.com/complex.js/-/complex.js-2.0.13.tgz#00cf7ba082565e164813b7bbbb0ced5d2aba172a"
   integrity sha512-UEWd3G3/kd3lJmsdLsDh9qfinJlujL4hIFn3Vo4/G5eqehPsgCHf2CLhFs77tVkOp2stt/jbNit7Q1XFANFltA==
 
+component-emitter@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
+  integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -2324,6 +2360,11 @@ cookie@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
   integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
+
+cookiejar@^2.1.0, cookiejar@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
+  integrity sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -2448,7 +2489,7 @@ debug@4.2.0:
   dependencies:
     ms "2.1.2"
 
-debug@^3.2.6, debug@^3.2.7:
+debug@^3.1.0, debug@^3.2.6, debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
@@ -3219,7 +3260,7 @@ ext@^1.1.2:
   dependencies:
     type "^2.0.0"
 
-extend@~3.0.2:
+extend@^3.0.0, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
@@ -3390,7 +3431,7 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
-form-data@^2.5.0:
+form-data@^2.3.1, form-data@^2.5.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
   integrity sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==
@@ -3407,6 +3448,11 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
+
+formidable@^1.2.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.2.tgz#bf69aea2972982675f00865342b982986f6b8dd9"
+  integrity sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q==
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -3913,6 +3959,11 @@ ioredis@^4.17.3:
     redis-parser "^3.0.0"
     standard-as-callback "^2.1.0"
 
+ip-regex@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
+  integrity sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
+
 ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
@@ -4017,6 +4068,13 @@ is-installed-globally@^0.3.1:
   dependencies:
     global-dirs "^2.0.1"
     is-path-inside "^3.0.1"
+
+is-ip@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-ip/-/is-ip-2.0.0.tgz#68eea07e8a0a0a94c2d080dd674c731ab2a461ab"
+  integrity sha1-aO6gfooKCpTC0IDdZ0xzGrKkYas=
+  dependencies:
+    ip-regex "^2.0.0"
 
 is-nan@^1.3.0:
   version "1.3.2"
@@ -4688,7 +4746,7 @@ merge-descriptors@1.0.1, merge-descriptors@~1.0.0:
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
   integrity sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
 
-methods@~1.1.2:
+methods@^1.1.1, methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
@@ -4705,7 +4763,7 @@ mime-types@^2.1.12, mime-types@~2.1.19, mime-types@~2.1.24:
   dependencies:
     mime-db "1.48.0"
 
-mime@1.6.0:
+mime@1.6.0, mime@^1.4.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
@@ -5712,6 +5770,13 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
+qs@^6.5.1:
+  version "6.10.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.1.tgz#4931482fa8d647a5aab799c5271d2133b981fb6a"
+  integrity sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==
+  dependencies:
+    side-channel "^1.0.4"
+
 qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
@@ -5813,7 +5878,7 @@ readable-stream@1.1.x:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@^2.0.6, readable-stream@^2.2.2, readable-stream@^2.3.7:
+readable-stream@^2.0.6, readable-stream@^2.2.2, readable-stream@^2.3.5, readable-stream@^2.3.7:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -6568,6 +6633,22 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
+
+superagent@^3.7.0:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.8.3.tgz#460ea0dbdb7d5b11bc4f78deba565f86a178e128"
+  integrity sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==
+  dependencies:
+    component-emitter "^1.2.0"
+    cookiejar "^2.1.0"
+    debug "^3.1.0"
+    extend "^3.0.0"
+    form-data "^2.3.1"
+    formidable "^1.2.0"
+    methods "^1.1.1"
+    mime "^1.4.1"
+    qs "^6.5.1"
+    readable-stream "^2.3.5"
 
 supports-color@7.2.0, supports-color@^7.1.0:
   version "7.2.0"


### PR DESCRIPTION
new endpoints
* /community/{id}/promoter
* /community/{id}/suspect
* /community/{id}/contract
* /community/{id}/state
* /community/{id}/metrics

All these endpoints are splitting what was being returned altogether in `/community/{id}`. To improve performance and reduced unnecessary queried information, `/community/{id}` will be returning less information in the future. To not break anything, we should migrate as soon as possible and keep `/community/{id}` returning everything for backward compatibility.

Please, consider the interface below the new result to `/community/{id}`. When some other information is needed, please, use the other endpoints. The results are now documented on swagger.

```javascript
export interface Community {
    id: number;
    requestByAddress: string;
    contractAddress: string | null;
    name: string;
    description: string;
    descriptionEn: string | null;
    language: string;
    currency: string;
    city: string;
    country: string;
    gps: {
        latitude: number;
        longitude: number;
    };
    email: string;
    visibility: 'public' | 'private';
    status: 'pending' | 'valid' | 'removed';

    // timestamps
    createdAt: Date;
    updatedAt: Date;

    cover?: AppMediaContent;
}
```