### PR TITLE
[IPCT1-279] add review column to community

### DIFF
--- a/src/database/migrations/create-community.js
+++ b/src/database/migrations/create-community.js
@@ -75,6 +75,16 @@ module.exports = {
                 type: Sequelize.ENUM('pending', 'valid', 'removed'),
                 allowNull: false,
             },
+            review: {
+                type: Sequelize.ENUM(
+                    'pending',
+                    'in-progress',
+                    'halted',
+                    'closed'
+                ),
+                default: 'pending',
+                allowNull: false,
+            },
             started: {
                 type: Sequelize.DATEONLY,
                 allowNull: false,

--- a/src/database/migrations/z1624645590-update-community.js
+++ b/src/database/migrations/z1624645590-update-community.js
@@ -1,0 +1,17 @@
+'use strict';
+
+// eslint-disable-next-line no-undef
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        if (process.env.NODE_ENV === 'test') {
+            return;
+        }
+        await queryInterface.addColumn('community', 'review', {
+            type: Sequelize.ENUM('pending', 'in-progress', 'halted', 'closed'),
+            allowNull: false,
+            defaultValue: 'pending',
+        });
+    },
+
+    down(queryInterface, Sequelize) {},
+};

--- a/src/database/models/ubi/community.ts
+++ b/src/database/models/ubi/community.ts
@@ -71,7 +71,6 @@ export interface CommunityCreationAttributes {
     coverImage?: string; // TODO: will be required once next version is released
     coverMediaId?: number; // TODO: will be required once next version is released
     status: 'pending' | 'valid' | 'removed'; // pending / valid / removed
-    review: 'pending' | 'in-progress' | 'halted' | 'closed';
     started: Date;
 }
 

--- a/src/database/models/ubi/community.ts
+++ b/src/database/models/ubi/community.ts
@@ -33,6 +33,7 @@ export interface CommunityAttributes {
     coverImage: string; // TODO: to be removed
     coverMediaId: number;
     status: 'pending' | 'valid' | 'removed'; // pending / valid / removed
+    review: 'pending' | 'in-progress' | 'halted' | 'closed';
     started: Date; // TODO: to be removed
 
     // timestamps
@@ -70,6 +71,7 @@ export interface CommunityCreationAttributes {
     coverImage?: string; // TODO: will be required once next version is released
     coverMediaId?: number; // TODO: will be required once next version is released
     status: 'pending' | 'valid' | 'removed'; // pending / valid / removed
+    review: 'pending' | 'in-progress' | 'halted' | 'closed';
     started: Date;
 }
 
@@ -97,6 +99,7 @@ export class Community extends Model<
     public coverImage!: string;
     public coverMediaId!: number | null; // TODO: will be required once next version is released
     public status!: 'pending' | 'valid' | 'removed'; // pending / valid / removed
+    public review!: 'pending' | 'in-progress' | 'halted' | 'closed';
     public started!: Date;
 
     // timestamps!
@@ -186,6 +189,16 @@ export function initializeCommunity(sequelize: Sequelize): void {
             },
             status: {
                 type: DataTypes.ENUM('pending', 'valid', 'removed'),
+                allowNull: false,
+            },
+            review: {
+                type: DataTypes.ENUM(
+                    'pending',
+                    'in-progress',
+                    'halted',
+                    'closed'
+                ),
+                defaultValue: 'pending',
                 allowNull: false,
             },
             started: {


### PR DESCRIPTION
This PR fixes [IPCT1-279] at https://impactmarket.atlassian.net/browse/IPCT1-279

## Changes
adds column `review` to community table, so that, community managers can filter by those they haven't looked at yet.

## Tests

no new tests