### PR TITLE
Add seeders 50 fake accounts

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-release: npx sequelize db:migrate --env $API_ENVIRONMENT
+release: ./release-tasks.sh
 web: yarn serve
 worker: yarn worker

--- a/release-tasks.sh
+++ b/release-tasks.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+npx sequelize db:migrate --env $API_ENVIRONMENT
+if [ $API_ENVIRONMENT != 'production' ] && [ $NODE_ENV != 'production' ] && [ $NODE_ENV != 'prod' ] && [ $NODE_ENV != 'PROD' ]
+then
+    npx sequelize-cli db:seed:all --env $API_ENVIRONMENT
+fi

--- a/src/database/migrations_config/config.js
+++ b/src/database/migrations_config/config.js
@@ -40,6 +40,8 @@ module.exports = {
         port: 5432,
         dialect: 'postgres',
         migrationStorageTableName: 'sequelize_meta',
+        seederStorage: 'sequelize',
+        seederStorageTableName: 'sequelize_data',
     },
     staging: {
         username,
@@ -49,6 +51,8 @@ module.exports = {
         port: 5432,
         dialect: 'postgres',
         migrationStorageTableName: 'sequelize_meta',
+        seederStorage: 'sequelize',
+        seederStorageTableName: 'sequelize_data',
         dialectOptions: {
             ssl: {
                 rejectUnauthorized: false,

--- a/src/database/seeders/20210727135114-demo-user.js
+++ b/src/database/seeders/20210727135114-demo-user.js
@@ -1,0 +1,171 @@
+'use strict';
+const { ethers } = require('ethers');
+const faker = require('faker');
+
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        if (
+            process.env.API_ENVIRONMENT === 'production' ||
+            process.env.NODE_ENV === 'production' ||
+            process.env.NODE_ENV === 'prod' ||
+            process.env.NODE_ENV === 'PROD'
+        ) {
+            return;
+        }
+        const totalNewUsers = 50;
+        const newUsers = [];
+        for (let index = 0; index < totalNewUsers; index++) {
+            const randomWallet = ethers.Wallet.createRandom();
+            newUsers.push({
+                address: await randomWallet.getAddress(),
+                username: faker.internet.userName(),
+                currency: faker.finance.currencyCode(),
+                trust: {
+                    phone: faker.phone.phoneNumber(),
+                },
+            });
+        }
+
+        const User = await queryInterface.sequelize.define(
+            'user',
+            {
+                address: {
+                    type: Sequelize.STRING(44),
+                    primaryKey: true,
+                    allowNull: false,
+                },
+                avatarMediaId: {
+                    type: Sequelize.INTEGER,
+                    // references: {
+                    //     model: 'app_media_content',
+                    //     key: 'id',
+                    // },
+                    // // onDelete: 'SET NULL', // default
+                    allowNull: true,
+                },
+                username: {
+                    type: Sequelize.STRING(128),
+                },
+                language: {
+                    type: Sequelize.STRING(8),
+                    defaultValue: 'en',
+                    allowNull: false,
+                },
+                currency: {
+                    type: Sequelize.STRING(4),
+                    defaultValue: 'USD',
+                },
+                pushNotificationToken: {
+                    type: Sequelize.STRING(64),
+                },
+                gender: {
+                    type: Sequelize.STRING(2),
+                },
+                year: {
+                    type: Sequelize.INTEGER,
+                },
+                children: {
+                    type: Sequelize.INTEGER,
+                },
+                lastLogin: {
+                    type: Sequelize.DATE,
+                    defaultValue: Sequelize.fn('now'),
+                    allowNull: false,
+                },
+                suspect: {
+                    type: Sequelize.BOOLEAN,
+                    defaultValue: false,
+                    allowNull: false,
+                },
+                createdAt: {
+                    allowNull: false,
+                    type: Sequelize.DATE,
+                    defaultValue: Sequelize.fn('now'),
+                },
+                updatedAt: {
+                    allowNull: false,
+                    type: Sequelize.DATE,
+                    defaultValue: Sequelize.fn('now'),
+                },
+            },
+            {
+                tableName: 'user',
+                sequelize: queryInterface.sequelize, // this bit is important
+            }
+        );
+
+        const AppUserTrust = await queryInterface.sequelize.define(
+            'app_user_trust',
+            {
+                id: {
+                    type: Sequelize.INTEGER,
+                    autoIncrement: true,
+                    primaryKey: true,
+                },
+                phone: {
+                    // hashed phone number
+                    type: Sequelize.STRING(64),
+                    allowNull: false,
+                },
+                verifiedPhoneNumber: {
+                    type: Sequelize.BOOLEAN,
+                    defaultValue: false,
+                },
+                suspect: {
+                    type: Sequelize.BOOLEAN,
+                    defaultValue: false,
+                },
+            },
+            {
+                tableName: 'app_user_trust',
+                sequelize: queryInterface.sequelize, // this bit is important
+                timestamps: false,
+            }
+        );
+
+        const AppUserThroughTrust = await queryInterface.sequelize.define(
+            'app_user_through_trust',
+            {
+                userAddress: {
+                    type: Sequelize.STRING(44),
+                    references: {
+                        model: 'user',
+                        key: 'address',
+                    },
+                    onDelete: 'CASCADE',
+                    allowNull: false,
+                },
+                appUserTrustId: {
+                    type: Sequelize.INTEGER,
+                    references: {
+                        model: 'app_user_trust',
+                        key: 'id',
+                    },
+                    onDelete: 'CASCADE',
+                    allowNull: false,
+                },
+            },
+            {
+                tableName: 'app_user_through_trust',
+                sequelize: queryInterface.sequelize, // this bit is important
+                timestamps: false,
+            }
+        );
+
+        User.belongsToMany(AppUserTrust, {
+            through: AppUserThroughTrust,
+            foreignKey: 'userAddress',
+            sourceKey: 'address',
+            as: 'trust',
+        });
+
+        await User.bulkCreate(newUsers, {
+            include: [
+                {
+                    model: AppUserTrust,
+                    as: 'trust',
+                },
+            ],
+        });
+    },
+};


### PR DESCRIPTION
## Changes
This PR adds a seeders migration script, adding 50 fake accounts. This will be useful for manual testing.
Also changes the release phase to include seeders migration.

See more about seeders https://sequelize.org/master/manual/migrations.html

## Tests
- no tests