### PR TITLE
[IPCT1-179] user should be able to migrate account asscociated with phone number

### DIFF
--- a/src/api/controllers/user.ts
+++ b/src/api/controllers/user.ts
@@ -40,7 +40,9 @@ class UserController {
             overwrite,
         })
             .then((user) => standardResponse(res, 201, true, user))
-            .catch((e) => standardResponse(res, 400, false, '', { error: e.message }));
+            .catch((e) =>
+                standardResponse(res, 400, false, '', { error: e.message })
+            );
     };
 
     public welcome = (req: RequestWithUser, res: Response) => {

--- a/src/api/controllers/user.ts
+++ b/src/api/controllers/user.ts
@@ -25,20 +25,22 @@ class UserController {
             avatarMediaId,
             overwrite,
         } = req.body;
-        UserService.authenticate({
-            address,
-            language,
-            currency,
-            pushNotificationToken,
-            username,
-            year,
-            children,
-            avatarMediaId,
-            trust: {
-                phone,
+        UserService.authenticate(
+            {
+                address,
+                language,
+                currency,
+                pushNotificationToken,
+                username,
+                year,
+                children,
+                avatarMediaId,
+                trust: {
+                    phone,
+                },
             },
-            overwrite,
-        })
+            overwrite
+        )
             .then((user) => standardResponse(res, 201, true, user))
             .catch((e) =>
                 standardResponse(res, 400, false, '', { error: e.message })

--- a/src/api/controllers/user.ts
+++ b/src/api/controllers/user.ts
@@ -23,6 +23,7 @@ class UserController {
             year,
             children,
             avatarMediaId,
+            overwrite,
         } = req.body;
         UserService.authenticate({
             address,
@@ -36,9 +37,10 @@ class UserController {
             trust: {
                 phone,
             },
+            overwrite,
         })
             .then((user) => standardResponse(res, 201, true, user))
-            .catch((e) => standardResponse(res, 400, false, '', { error: e }));
+            .catch((e) => standardResponse(res, 400, false, '', { error: e.message }));
     };
 
     public welcome = (req: RequestWithUser, res: Response) => {

--- a/src/api/validators/user.ts
+++ b/src/api/validators/user.ts
@@ -19,6 +19,7 @@ const auth = celebrate({
         year: Joi.number().optional(),
         children: Joi.number().optional(),
         avatarMediaId: Joi.number().optional(),
+        overwrite: Joi.boolean().optional(),
     }),
 });
 

--- a/src/database/migrations/create-user.js
+++ b/src/database/migrations/create-user.js
@@ -50,6 +50,11 @@ module.exports = {
                 defaultValue: false,
                 allowNull: false,
             },
+            active: {
+                type: Sequelize.BOOLEAN,
+                defaultValue: true,
+                allowNull: false,
+            },
             createdAt: {
                 allowNull: false,
                 type: Sequelize.DATE,

--- a/src/database/migrations/z1627953863-update-user.js
+++ b/src/database/migrations/z1627953863-update-user.js
@@ -6,8 +6,8 @@ module.exports = {
         if (process.env.NODE_ENV === 'test') {
             return;
         }
-        await queryInterface.changeColumn('user', 'active', {
-            type: Sequelize.BOOLEAN(),
+        await queryInterface.addColumn('user', 'active', {
+            type: Sequelize.BOOLEAN,
             defaultValue: true,
             allowNull: false,
         });

--- a/src/database/migrations/z1627953863-update-user.js
+++ b/src/database/migrations/z1627953863-update-user.js
@@ -1,0 +1,17 @@
+'use strict';
+
+// eslint-disable-next-line no-undef
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        if (process.env.NODE_ENV === 'test') {
+            return;
+        }
+        await queryInterface.changeColumn('user', 'active', {
+            type: Sequelize.BOOLEAN(),
+            defaultValue: true,
+            allowNull: false,
+        });
+    },
+
+    down(queryInterface, Sequelize) {},
+};

--- a/src/database/models/app/user.ts
+++ b/src/database/models/app/user.ts
@@ -13,6 +13,7 @@ export class UserModel extends Model<User, UserCreationAttributes> {
     public children!: number | null;
     public lastLogin!: Date;
     public suspect!: boolean;
+    public active!: boolean;
 
     // timestamps!
     public readonly createdAt!: Date;
@@ -69,6 +70,11 @@ export function initializeUser(sequelize: Sequelize): typeof UserModel {
             suspect: {
                 type: DataTypes.BOOLEAN,
                 defaultValue: false,
+                allowNull: false,
+            },
+            active: {
+                type: DataTypes.BOOLEAN,
+                defaultValue: true,
                 allowNull: false,
             },
             createdAt: {

--- a/src/interfaces/app/user.ts
+++ b/src/interfaces/app/user.ts
@@ -103,5 +103,4 @@ export interface UserCreationAttributes {
     pushNotificationToken?: string;
 
     trust?: AppUserTrustCreation;
-    overwrite?: boolean;
 }

--- a/src/interfaces/app/user.ts
+++ b/src/interfaces/app/user.ts
@@ -78,6 +78,7 @@ export interface User {
     children: number | null;
     lastLogin: Date;
     suspect: boolean;
+    active: boolean;
 
     // timestamps
     createdAt: Date;
@@ -102,4 +103,5 @@ export interface UserCreationAttributes {
     pushNotificationToken?: string;
 
     trust?: AppUserTrustCreation;
+    overwrite?: boolean;
 }

--- a/src/services/app/user.ts
+++ b/src/services/app/user.ts
@@ -27,7 +27,8 @@ export default class UserService {
     private static profileContentStorage = new ProfileContentStorage();
 
     public static async authenticate(
-        user: UserCreationAttributes
+        user: UserCreationAttributes,
+        overwrite: boolean = false
     ): Promise<IUserAuth> {
         try {
             // generate access token for future interactions that require authentication
@@ -37,7 +38,7 @@ export default class UserService {
                 ? await this.existsAccountByPhone(user.trust.phone)
                 : false;
 
-            if (user.overwrite) {
+            if (overwrite) {
                 await this.overwriteUser(user);
             } else if (!exists && existsPhone) {
                 throw 'phone associated with another account';

--- a/tests/integration/services/user.test.ts
+++ b/tests/integration/services/user.test.ts
@@ -231,8 +231,7 @@ describe('user service', () => {
                 trust: {
                     phone,
                 },
-                overwrite: true,
-            });
+            }, true);
 
             const findUser = await models.user.findOne({
                 where: { address: firstAddress },
@@ -269,8 +268,7 @@ describe('user service', () => {
                 trust: {
                     phone,
                 },
-                overwrite: true,
-            });
+            }, true);
 
             let error: any;
 

--- a/tests/integration/services/user.test.ts
+++ b/tests/integration/services/user.test.ts
@@ -4,8 +4,8 @@ import faker from 'faker';
 import { Sequelize } from 'sequelize';
 
 import { models } from '../../../src/database';
-import { UserModel } from '../../../src/database/models/app/user';
 import { CommunityAttributes } from '../../../src/database/models/ubi/community';
+import { User } from '../../../src/interfaces/app/user';
 import UserService from '../../../src/services/app/user';
 import CommunityFactory from '../../factories/community';
 import UserFactory from '../../factories/user';
@@ -33,7 +33,7 @@ describe('user service', () => {
                     phone,
                 },
             });
-            const findUser = await sequelize.models.UserModel.findOne({
+            const findUser = await models.user.findOne({
                 where: { address: newUser.user.address },
             });
             const findPhone = await sequelize.models.AppUserTrustModel.findOne({
@@ -67,7 +67,7 @@ describe('user service', () => {
                     phone,
                 },
             });
-            const findUser = await sequelize.models.UserModel.findOne({
+            const findUser = await models.user.findOne({
                 where: { address: newUser.user.address },
             });
             const findPhone = await sequelize.models.AppUserTrustModel.findOne({
@@ -108,7 +108,7 @@ describe('user service', () => {
                     phone,
                 },
             });
-            const findUser = await sequelize.models.UserModel.findOne({
+            const findUser = await models.user.findOne({
                 where: { address: loadUser.user.address },
             });
             const findPhone = await sequelize.models.AppUserTrustModel.findOne({
@@ -160,7 +160,7 @@ describe('user service', () => {
                     phone,
                 },
             });
-            const findUser = await sequelize.models.UserModel.findOne({
+            const findUser = await models.user.findOne({
                 where: { address: loadUser.user.address },
             });
             const findPhone = await sequelize.models.AppUserTrustModel.findOne({
@@ -203,11 +203,13 @@ describe('user service', () => {
                 trust: {
                     phone,
                 },
-            }).catch(err => {
+            }).catch((err) => {
                 error = err;
             });
 
-            expect(error.message).to.equal('phone associated with another account')
+            expect(error.message).to.equal(
+                'phone associated with another account'
+            );
         });
 
         it('authentication should inactivate the old account and create a new', async () => {
@@ -232,15 +234,15 @@ describe('user service', () => {
                 overwrite: true,
             });
 
-            const findUser = await sequelize.models.UserModel.findOne({
+            const findUser = await models.user.findOne({
                 where: { address: firstAddress },
             });
-            const user = findUser?.toJSON() as UserModel
+            const user = findUser?.toJSON() as User;
 
             expect(loadUser.user).to.include({
                 address: secondAddress,
                 suspect: false,
-                active: true
+                active: true,
             });
 
             expect(user.active).to.be.false;
@@ -278,11 +280,11 @@ describe('user service', () => {
                 trust: {
                     phone,
                 },
-            }).catch(err => {
+            }).catch((err) => {
                 error = err;
-            })
+            });
 
-            expect(error.message).to.equal('user inactive')
+            expect(error.message).to.equal('user inactive');
         });
     });
 


### PR DESCRIPTION
This PR fixes [IPCT1-179] at https://impactmarket.atlassian.net/browse/IPCT1-179

## Changes
- change authentication service to validate if the user already has another account and enable account migration.

## New
- included column "active" on user table.
- included "overwrite" as input parameter in endpoint /auth


## Tests
- added some integration tests on user.test.ts