### PR TITLE
[IPCT1-312] - add nearest first/last and most beneficiaries first/last sort to communities

### DIFF
--- a/src/api/controllers/community.ts
+++ b/src/api/controllers/community.ts
@@ -37,7 +37,9 @@ class CommunityController {
             .then((r) =>
                 standardResponse(res, 200, true, r.rows, { count: r.count })
             )
-            .catch((e) => standardResponse(res, 400, false, '', { error: e }));
+            .catch((e) =>
+                standardResponse(res, 400, false, '', { error: e.message })
+            );
     };
 
     count = (req: Request, res: Response) => {

--- a/src/services/ubi/community.ts
+++ b/src/services/ubi/community.ts
@@ -303,6 +303,7 @@ export default class CommunityService {
 
     public static async list(query: {
         orderBy?: string;
+        orderType?: string;
         filter?: string;
         name?: string;
         country?: string;
@@ -337,7 +338,7 @@ export default class CommunityService {
                                 lat +
                                 "))*sin(radians(cast(gps->>'latitude' as float)))))"
                         ),
-                        'ASC',
+                        query.orderType ? query.orderType : 'ASC',
                     ],
                 ];
                 break;
@@ -355,16 +356,21 @@ export default class CommunityService {
                         literal(
                             '(state.raised - state.claimed) / metrics."ubiRate" / state.beneficiaries'
                         ),
-                        'ASC',
+                        query.orderType ? query.orderType : 'ASC',
                     ],
                 ];
                 break;
             }
             case 'newest':
-                orderOption = [[literal('"Community".started'), 'DESC']];
+                orderOption = [[literal('"Community".started'), query.orderType ? query.orderType : 'DESC']];
                 break;
             default:
-                orderOption = [[literal('state.beneficiaries'), 'DESC']];
+                orderOption = [
+                    [
+                        literal('state.beneficiaries'),
+                        query.orderType ? query.orderType : 'DESC',
+                    ],
+                ];
                 break;
         }
 

--- a/src/services/ubi/community.ts
+++ b/src/services/ubi/community.ts
@@ -313,26 +313,32 @@ export default class CommunityService {
         lng?: string;
     }): Promise<{ count: number; rows: CommunityAttributes[] }> {
         let extendedWhere: WhereOptions<CommunityAttributes> = {};
-        let orderOption: OrderItem[] = [];
+        const orderOption: OrderItem[] = [];
         const extendedInclude: Includeable[] = [];
 
-        if(query.orderBy) {
+        if (query.orderBy) {
             const orders = query.orderBy.split(';');
 
-            orders.forEach(element => {
+            orders.forEach((element) => {
                 const [order, orderType] = element.split(':');
 
                 switch (order) {
                     case 'nearest': {
-                        if (query.lat === undefined || query.lng === undefined) {
+                        if (
+                            query.lat === undefined ||
+                            query.lng === undefined
+                        ) {
                             throw new Error('invalid coordinates');
                         }
                         const lat = parseInt(query.lat, 10);
                         const lng = parseInt(query.lng, 10);
-                        if (typeof lat !== 'number' || typeof lng !== 'number') {
+                        if (
+                            typeof lat !== 'number' ||
+                            typeof lng !== 'number'
+                        ) {
                             throw new Error('NaN');
                         }
-                        
+
                         orderOption.push([
                             literal(
                                 '(6371*acos(cos(radians(' +
@@ -344,7 +350,7 @@ export default class CommunityService {
                                     "))*sin(radians(cast(gps->>'latitude' as float)))))"
                             ),
                             orderType ? orderType : 'ASC',
-                        ])
+                        ]);
                         break;
                     }
                     case 'out_of_funds': {
@@ -360,11 +366,14 @@ export default class CommunityService {
                                 '(state.raised - state.claimed) / metrics."ubiRate" / state.beneficiaries'
                             ),
                             orderType ? orderType : 'ASC',
-                        ])
+                        ]);
                         break;
                     }
                     case 'newest':
-                        orderOption.push([literal('"Community".started'), orderType ? orderType : 'DESC']);
+                        orderOption.push([
+                            literal('"Community".started'),
+                            orderType ? orderType : 'DESC',
+                        ]);
                         break;
                     default:
                         orderOption.push([

--- a/tests/factories/community.ts
+++ b/tests/factories/community.ts
@@ -21,6 +21,10 @@ interface ICreateProps {
     hasAddress?: boolean;
     name?: string;
     country?: string;
+    gps?: {
+        latitude: number;
+        longitude: number;
+    };
 }
 /**
  * Generate an object which container attributes needed
@@ -37,10 +41,12 @@ const data = async (props: ICreateProps) => {
         currency: faker.finance.currencyCode(),
         description: faker.lorem.sentence(),
         email: faker.internet.email(),
-        gps: {
-            latitude: 0,
-            longitude: 0,
-        },
+        gps: props.gps
+            ? props.gps
+            : {
+                  latitude: 0,
+                  longitude: 0,
+              },
         language: 'pt',
         name: props.name ? props.name : faker.company.companyName(),
         coverMediaId: 0,

--- a/tests/integration/services/community.test.ts
+++ b/tests/integration/services/community.test.ts
@@ -504,8 +504,7 @@ describe('community service', () => {
                 ]);
 
                 const result = await CommunityService.list({
-                    orderBy: 'nearest',
-                    orderType: 'asc',
+                    orderBy: 'nearest:ASC;bigger:DESC',
                     lat: '-23.4378873',
                     lng: '-46.4841214',
                 });
@@ -559,8 +558,7 @@ describe('community service', () => {
                 ]);
 
                 const result = await CommunityService.list({
-                    orderBy: 'nearest',
-                    orderType: 'desc',
+                    orderBy: 'nearest:DESC;bigger:ASC',
                     lat: '-23.4378873',
                     lng: '-46.4841214',
                 });

--- a/tests/integration/services/community.test.ts
+++ b/tests/integration/services/community.test.ts
@@ -457,6 +457,122 @@ describe('community service', () => {
                 result.push(r.rows);
             }
         }).timeout(120000); // exceptionally 120s timeout
+
+        describe('sort', () => {
+            afterEach(async () => {
+                await truncate(sequelize, 'Community');
+            });
+
+            it('nearest', async () => {
+                const communities = await CommunityFactory([
+                    {
+                        requestByAddress: users[0].address,
+                        started: new Date(),
+                        status: 'valid',
+                        visibility: 'public',
+                        contract: {
+                            baseInterval: 60 * 60 * 24,
+                            claimAmount: '1000000000000000000',
+                            communityId: 0,
+                            incrementInterval: 5 * 60,
+                            maxClaim: '450000000000000000000',
+                        },
+                        hasAddress: true,
+                        gps: {
+                            latitude: -23.4378873,
+                            longitude: -46.4841214,
+                        },
+                    },
+                    {
+                        requestByAddress: users[1].address,
+                        started: new Date(),
+                        status: 'valid',
+                        visibility: 'public',
+                        contract: {
+                            baseInterval: 60 * 60 * 24,
+                            claimAmount: '1000000000000000000',
+                            communityId: 0,
+                            incrementInterval: 5 * 60,
+                            maxClaim: '450000000000000000000',
+                        },
+                        hasAddress: true,
+                        gps: {
+                            latitude: -15.8697203,
+                            longitude: -47.9207824,
+                        },
+                    },
+                ]);
+
+                const result = await CommunityService.list({
+                    orderBy: 'nearest',
+                    orderType: 'asc',
+                    lat: '-23.4378873',
+                    lng: '-46.4841214',
+                });
+
+                expect(result.rows[0]).to.include({
+                    id: communities[0].id,
+                    name: communities[0].name,
+                    country: communities[0].country,
+                    requestByAddress: users[0].address,
+                });
+            });
+
+            it('farthest', async () => {
+                const communities = await CommunityFactory([
+                    {
+                        requestByAddress: users[0].address,
+                        started: new Date(),
+                        status: 'valid',
+                        visibility: 'public',
+                        contract: {
+                            baseInterval: 60 * 60 * 24,
+                            claimAmount: '1000000000000000000',
+                            communityId: 0,
+                            incrementInterval: 5 * 60,
+                            maxClaim: '450000000000000000000',
+                        },
+                        hasAddress: true,
+                        gps: {
+                            latitude: -23.4378873,
+                            longitude: -46.4841214,
+                        },
+                    },
+                    {
+                        requestByAddress: users[1].address,
+                        started: new Date(),
+                        status: 'valid',
+                        visibility: 'public',
+                        contract: {
+                            baseInterval: 60 * 60 * 24,
+                            claimAmount: '1000000000000000000',
+                            communityId: 0,
+                            incrementInterval: 5 * 60,
+                            maxClaim: '450000000000000000000',
+                        },
+                        hasAddress: true,
+                        gps: {
+                            latitude: -15.8697203,
+                            longitude: -47.9207824,
+                        },
+                    },
+                ]);
+
+                const result = await CommunityService.list({
+                    orderBy: 'nearest',
+                    orderType: 'desc',
+                    lat: '-23.4378873',
+                    lng: '-46.4841214',
+                });
+
+                expect(result.rows[0]).to.include({
+                    id: communities[1].id,
+                    name: communities[1].name,
+                    country: communities[1].country,
+                    requestByAddress: users[1].address,
+                });
+            });
+        });
     });
 
     describe('campaign', () => {

--- a/tests/integration/services/community.test.ts
+++ b/tests/integration/services/community.test.ts
@@ -579,7 +579,10 @@ describe('community service', () => {
                 for (const community of communities) {
                     await BeneficiaryFactory(
                         await UserFactory({
-                            n: community.requestByAddress === users[1].address ? 5 : 4,
+                            n:
+                                community.requestByAddress === users[1].address
+                                    ? 5
+                                    : 4,
                         }),
                         community.publicId
                     );
@@ -672,7 +675,10 @@ describe('community service', () => {
                 for (const community of communities) {
                     await BeneficiaryFactory(
                         await UserFactory({
-                            n: community.requestByAddress === users[2].address ? 3 : 4,
+                            n:
+                                community.requestByAddress === users[2].address
+                                    ? 3
+                                    : 4,
                         }),
                         community.publicId
                     );


### PR DESCRIPTION
This PR fixes [IPCT1-312] at https://impactmarket.atlassian.net/browse/IPCT1-312

## Changes
added "orderType" on the query of community list to be able to order ascending and descending.

## New

<!---
Specify what's new. New endpoints, etc.
-->

## Tests
added new tests on community.test.ts to test the list order