### PR TITLE
fix: default sort on the community list

### DIFF
--- a/src/services/ubi/community.ts
+++ b/src/services/ubi/community.ts
@@ -383,6 +383,8 @@ export default class CommunityService {
                         break;
                 }
             });
+        } else {
+            orderOption.push([literal('state.beneficiaries'), 'DESC']);
         }
 
         if (query.filter === 'featured') {

--- a/tests/integration/services/community.test.ts
+++ b/tests/integration/services/community.test.ts
@@ -464,6 +464,74 @@ describe('community service', () => {
                 await truncate(sequelize, 'Community');
             });
 
+            it('without query parameters (most beneficiaries)', async () => {
+                const communities = await CommunityFactory([
+                    {
+                        requestByAddress: users[0].address,
+                        started: new Date(),
+                        status: 'valid',
+                        visibility: 'public',
+                        contract: {
+                            baseInterval: 60 * 60 * 24,
+                            claimAmount: '1000000000000000000',
+                            communityId: 0,
+                            incrementInterval: 5 * 60,
+                            maxClaim: '450000000000000000000',
+                        },
+                        hasAddress: true,
+                        gps: {
+                            latitude: -23.4378873,
+                            longitude: -46.4841214,
+                        },
+                    },
+                    {
+                        requestByAddress: users[1].address,
+                        started: new Date(),
+                        status: 'valid',
+                        visibility: 'public',
+                        contract: {
+                            baseInterval: 60 * 60 * 24,
+                            claimAmount: '1000000000000000000',
+                            communityId: 0,
+                            incrementInterval: 5 * 60,
+                            maxClaim: '450000000000000000000',
+                        },
+                        hasAddress: true,
+                        gps: {
+                            latitude: -23.4378873,
+                            longitude: -46.4841214,
+                        },
+                    },
+                ]);
+
+                for (const community of communities) {
+                    await BeneficiaryFactory(
+                        await UserFactory({
+                            n:
+                                community.requestByAddress === users[0].address
+                                    ? 3
+                                    : 4,
+                        }),
+                        community.publicId
+                    );
+                }
+
+                const result = await CommunityService.list({});
+
+                expect(result.rows[0]).to.include({
+                    id: communities[1].id,
+                    name: communities[1].name,
+                    country: communities[1].country,
+                    requestByAddress: users[1].address,
+                });
+                expect(result.rows[1]).to.include({
+                    id: communities[0].id,
+                    name: communities[0].name,
+                    country: communities[0].country,
+                    requestByAddress: users[0].address,
+                });
+            });
+
             it('nearest', async () => {
                 const communities = await CommunityFactory([
                     {


### PR DESCRIPTION
## Changes
A default sort was added on the community list, to sort by most beneficiaries when no query parameter is sent

## New

<!---
Specify what's new. New endpoints, etc.
-->

## Tests
New test on community.test to test the service without passing a query parameter.