### PR TITLE
[IPCT1-364] - community should be able to edit email

### DIFF
--- a/src/api/controllers/community.ts
+++ b/src/api/controllers/community.ts
@@ -17,7 +17,10 @@ class CommunityController {
     };
 
     findByContractAddress = (req: RequestWithUser, res: Response) => {
-        CommunityService.findByContractAddress(req.params.address, req.user?.address)
+        CommunityService.findByContractAddress(
+            req.params.address,
+            req.user?.address
+        )
             .then((community) =>
                 standardResponse(res, 200, !!community, community)
             )
@@ -110,7 +113,10 @@ class CommunityController {
     };
 
     findById = (req: RequestWithUser, res: Response) => {
-        CommunityService.findById(parseInt(req.params.id, 10), req.user?.address)
+        CommunityService.findById(
+            parseInt(req.params.id, 10),
+            req.user?.address
+        )
             .then((community) => standardResponse(res, 200, true, community))
             .catch((e) => standardResponse(res, 400, false, '', { error: e }));
     };
@@ -235,7 +241,8 @@ class CommunityController {
                             coverMediaId,
                             email,
                         },
-                        req.user?.address)
+                        req.user?.address
+                    )
                         .then((community) =>
                             standardResponse(res, 200, true, community)
                         )

--- a/src/api/controllers/community.ts
+++ b/src/api/controllers/community.ts
@@ -16,8 +16,8 @@ class CommunityController {
             .catch((e) => standardResponse(res, 400, false, '', { error: e }));
     };
 
-    findByContractAddress = (req: Request, res: Response) => {
-        CommunityService.findByContractAddress(req.params.address)
+    findByContractAddress = (req: RequestWithUser, res: Response) => {
+        CommunityService.findByContractAddress(req.params.address, req.user?.address)
             .then((community) =>
                 standardResponse(res, 200, !!community, community)
             )
@@ -109,8 +109,8 @@ class CommunityController {
             .catch((e) => standardResponse(res, 400, false, '', { error: e }));
     };
 
-    findById = (req: Request, res: Response) => {
-        CommunityService.findById(parseInt(req.params.id, 10))
+    findById = (req: RequestWithUser, res: Response) => {
+        CommunityService.findById(parseInt(req.params.id, 10), req.user?.address)
             .then((community) => standardResponse(res, 200, true, community))
             .catch((e) => standardResponse(res, 400, false, '', { error: e }));
     };
@@ -218,7 +218,7 @@ class CommunityController {
             });
             return;
         }
-        const { name, description, currency, coverMediaId } = req.body;
+        const { name, description, currency, coverMediaId, email } = req.body;
         // verify if the current user is manager in this community
         ManagerService.get(req.user.address)
             .then(async (manager) => {
@@ -226,12 +226,16 @@ class CommunityController {
                     const community = await CommunityService.getByPublicId(
                         manager.communityId
                     );
-                    CommunityService.edit(community!.id, {
-                        name,
-                        description,
-                        currency,
-                        coverMediaId,
-                    })
+                    CommunityService.edit(
+                        community!.id,
+                        {
+                            name,
+                            description,
+                            currency,
+                            coverMediaId,
+                            email,
+                        },
+                        req.user?.address)
                         .then((community) =>
                             standardResponse(res, 200, true, community)
                         )

--- a/src/api/middlewares/index.ts
+++ b/src/api/middlewares/index.ts
@@ -50,6 +50,15 @@ export function authenticateToken(
     });
 }
 
+export function optionalAuthentication(
+    req: RequestWithUser,
+    res: Response,
+    next: NextFunction
+): void {
+    req['authTokenIsOptional'] = true;
+    authenticateToken(req, res, next);
+}
+
 export function generateAccessToken(userAddress: string): string {
     return jwt.sign(
         { address: userAddress, masterKey: config.masterKey } as UserInRequest,

--- a/src/api/routes/community.ts
+++ b/src/api/routes/community.ts
@@ -407,7 +407,14 @@ export default (app: Router): void => {
      *             schema:
      *               $ref: '#/components/schemas/UbiCommunity'
      */
-    route.get('/address/:address', controller.findByContractAddress);
+    route.get('/address/:address',
+        (req, res, next) => {
+            (req as any).authTokenIsOptional = true;
+            next();
+        },
+        authenticateToken,
+        controller.findByContractAddress
+    );
 
     /**
      * @swagger
@@ -835,7 +842,14 @@ export default (app: Router): void => {
      *             schema:
      *               $ref: '#/components/schemas/UbiCommunity'
      */
-    route.get('/:id', controller.findById);
+    route.get('/:id',
+        (req, res, next) => {
+            (req as any).authTokenIsOptional = true;
+            next();
+        },
+        authenticateToken,
+        controller.findById
+    );
 
     /**
      * @swagger

--- a/src/api/routes/community.ts
+++ b/src/api/routes/community.ts
@@ -3,7 +3,11 @@ import communityValidators from '@validators/community';
 import { Router } from 'express';
 
 import { cacheWithRedis } from '../../database';
-import { adminAuthentication, authenticateToken } from '../middlewares';
+import {
+    adminAuthentication,
+    authenticateToken,
+    optionalAuthentication,
+} from '../middlewares';
 
 /**
  * @swagger
@@ -409,11 +413,7 @@ export default (app: Router): void => {
      */
     route.get(
         '/address/:address',
-        (req, res, next) => {
-            (req as any).authTokenIsOptional = true;
-            next();
-        },
-        authenticateToken,
+        optionalAuthentication,
         controller.findByContractAddress
     );
 
@@ -843,15 +843,7 @@ export default (app: Router): void => {
      *             schema:
      *               $ref: '#/components/schemas/UbiCommunity'
      */
-    route.get(
-        '/:id',
-        (req, res, next) => {
-            (req as any).authTokenIsOptional = true;
-            next();
-        },
-        authenticateToken,
-        controller.findById
-    );
+    route.get('/:id', optionalAuthentication, controller.findById);
 
     /**
      * @swagger

--- a/src/api/routes/community.ts
+++ b/src/api/routes/community.ts
@@ -407,7 +407,8 @@ export default (app: Router): void => {
      *             schema:
      *               $ref: '#/components/schemas/UbiCommunity'
      */
-    route.get('/address/:address',
+    route.get(
+        '/address/:address',
         (req, res, next) => {
             (req as any).authTokenIsOptional = true;
             next();
@@ -842,7 +843,8 @@ export default (app: Router): void => {
      *             schema:
      *               $ref: '#/components/schemas/UbiCommunity'
      */
-    route.get('/:id',
+    route.get(
+        '/:id',
         (req, res, next) => {
             (req as any).authTokenIsOptional = true;
             next();

--- a/src/api/routes/story.ts
+++ b/src/api/routes/story.ts
@@ -3,7 +3,7 @@ import StoryValidator from '@validators/story';
 import { Router } from 'express';
 
 import { cacheWithRedis } from '../../database';
-import { authenticateToken } from '../middlewares';
+import { authenticateToken, optionalAuthentication } from '../middlewares';
 
 export default (app: Router): void => {
     const storyController = new StoryController();
@@ -229,11 +229,7 @@ export default (app: Router): void => {
      */
     route.get(
         '/community/:id/:query?',
-        (req, res, next) => {
-            (req as any).authTokenIsOptional = true;
-            next();
-        },
-        authenticateToken,
+        optionalAuthentication,
         storyController.getByCommunity
     );
 

--- a/src/database/models/ubi/community.ts
+++ b/src/database/models/ubi/community.ts
@@ -165,9 +165,6 @@ export function initializeCommunity(sequelize: Sequelize): void {
             email: {
                 type: DataTypes.STRING(64),
                 allowNull: false,
-                get() {
-                    return '';
-                },
             },
             visibility: {
                 type: DataTypes.ENUM('public', 'private'),

--- a/src/services/ubi/community.ts
+++ b/src/services/ubi/community.ts
@@ -1379,8 +1379,6 @@ export default class CommunityService {
                 where: { address: userAddress, active: true },
             });
             if (manager !== null) {
-                const communityId = (manager.toJSON() as ManagerAttributes)
-                    .communityId;
                 showEmail = manager.communityId === community.publicId;
             }
         }

--- a/src/services/ubi/community.ts
+++ b/src/services/ubi/community.ts
@@ -190,7 +190,7 @@ export default class CommunityService {
             coverMediaId: number;
             email?: string;
         },
-        userAddress?: string,
+        userAddress?: string
     ): Promise<CommunityAttributes> {
         const community = await this.community.findOne({
             attributes: ['coverMediaId'],
@@ -432,7 +432,7 @@ export default class CommunityService {
 
         const communitiesResult = await this.community.findAndCountAll({
             attributes: {
-                exclude: ['email']
+                exclude: ['email'],
             },
             where: {
                 status: 'valid',
@@ -486,13 +486,16 @@ export default class CommunityService {
         });
     }
 
-    public static async findById(id: number, userAddress?: string): Promise<CommunityAttributes> {      
+    public static async findById(
+        id: number,
+        userAddress?: string
+    ): Promise<CommunityAttributes> {
         return this._findCommunityBy({ id }, userAddress);
     }
 
     public static async findByContractAddress(
         contractAddress: string,
-        userAddress?: string,
+        userAddress?: string
     ): Promise<CommunityAttributes> {
         return this._findCommunityBy({ contractAddress }, userAddress);
     }
@@ -500,7 +503,7 @@ export default class CommunityService {
     public static async getDashboard(id: string) {
         const result = await this.community.findOne({
             attributes: {
-                exclude: ['email']
+                exclude: ['email'],
             },
             include: [
                 {
@@ -1370,14 +1373,15 @@ export default class CommunityService {
         const metrics = await this.getMetrics(community.id);
 
         let showEmail = false;
-        if(userAddress) {
+        if (userAddress) {
             const manager = await models.manager.findOne({
                 attributes: ['communityId'],
                 where: { address: userAddress, active: true },
             });
             if (manager !== null) {
-                const communityId = (manager.toJSON() as ManagerAttributes).communityId;
-                showEmail = communityId === community.publicId
+                const communityId = (manager.toJSON() as ManagerAttributes)
+                    .communityId;
+                showEmail = communityId === community.publicId;
             }
         }
 

--- a/tests/integration/services/community.test.ts
+++ b/tests/integration/services/community.test.ts
@@ -1034,9 +1034,11 @@ describe('community service', () => {
         });
 
         it('update email', async () => {
+            const manager = await UserFactory({ n: 1 });
+
             const communities = await CommunityFactory([
                 {
-                    requestByAddress: users[0].address,
+                    requestByAddress: manager[0].address,
                     started: new Date(),
                     status: 'valid',
                     visibility: 'public',
@@ -1051,7 +1053,7 @@ describe('community service', () => {
                 },
             ]);
 
-            await ManagerFactory([users[0]], communities[0].publicId);
+            await ManagerFactory([manager[0]], communities[0].publicId);
 
             const communityNewDescription =
                 'bla bla bla, this community to the moon!';
@@ -1064,7 +1066,7 @@ describe('community service', () => {
                     coverMediaId: 1,
                     email: 'test@gmail.com',
                 },
-                users[0].address
+                manager[0].address
             );
 
             expect(updatedCommunity.description).to.be.equal(
@@ -1138,9 +1140,11 @@ describe('community service', () => {
         });
 
         it('find by id - manager request', async () => {
+            const manager = await UserFactory({ n: 1 });
+
             const communities = await CommunityFactory([
                 {
-                    requestByAddress: users[0].address,
+                    requestByAddress: manager[0].address,
                     started: new Date(),
                     status: 'valid',
                     visibility: 'public',
@@ -1155,11 +1159,11 @@ describe('community service', () => {
                 },
             ]);
 
-            await ManagerFactory([users[0]], communities[0].publicId);
+            await ManagerFactory([manager[0]], communities[0].publicId);
 
             const result = await CommunityService.findById(
                 communities[0].id,
-                users[0].address
+                manager[0].address
             );
 
             expect(result.publicId).to.be.equal(communities[0].publicId);
@@ -1167,9 +1171,11 @@ describe('community service', () => {
         });
 
         it('find by id - common user request', async () => {
+            const manager = await UserFactory({ n: 1 });
+
             const communities = await CommunityFactory([
                 {
-                    requestByAddress: users[0].address,
+                    requestByAddress: manager[0].address,
                     started: new Date(),
                     status: 'valid',
                     visibility: 'public',
@@ -1184,21 +1190,20 @@ describe('community service', () => {
                 },
             ]);
 
-            await ManagerFactory([users[0]], communities[0].publicId);
+            await ManagerFactory([manager[0]], communities[0].publicId);
 
-            const result = await CommunityService.findById(
-                communities[0].id,
-                users[1].address
-            );
+            const result = await CommunityService.findById(communities[0].id);
 
             expect(result.publicId).to.be.equal(communities[0].publicId);
             expect(result.email).to.be.equal('');
         });
 
         it('find by Contract Address - manager request', async () => {
+            const manager = await UserFactory({ n: 1 });
+
             const communities = await CommunityFactory([
                 {
-                    requestByAddress: users[0].address,
+                    requestByAddress: manager[0].address,
                     started: new Date(),
                     status: 'valid',
                     visibility: 'public',
@@ -1213,11 +1218,11 @@ describe('community service', () => {
                 },
             ]);
 
-            await ManagerFactory([users[0]], communities[0].publicId);
+            await ManagerFactory([manager[0]], communities[0].publicId);
 
             const result = await CommunityService.findByContractAddress(
                 communities[0].contractAddress!,
-                users[0].address
+                manager[0].address
             );
 
             expect(result.publicId).to.be.equal(communities[0].publicId);
@@ -1225,9 +1230,11 @@ describe('community service', () => {
         });
 
         it('find by Contract Address - common user request', async () => {
+            const manager = await UserFactory({ n: 1 });
+
             const communities = await CommunityFactory([
                 {
-                    requestByAddress: users[0].address,
+                    requestByAddress: manager[0].address,
                     started: new Date(),
                     status: 'valid',
                     visibility: 'public',
@@ -1242,11 +1249,10 @@ describe('community service', () => {
                 },
             ]);
 
-            await ManagerFactory([users[0]], communities[0].publicId);
+            await ManagerFactory([manager[0]], communities[0].publicId);
 
             const result = await CommunityService.findByContractAddress(
-                communities[0].contractAddress!,
-                users[1].address
+                communities[0].contractAddress!
             );
 
             expect(result.publicId).to.be.equal(communities[0].publicId);

--- a/tests/integration/services/community.test.ts
+++ b/tests/integration/services/community.test.ts
@@ -10,9 +10,9 @@ import { CommunityContentStorage } from '../../../src/services/storage';
 import CommunityService from '../../../src/services/ubi/community';
 import BeneficiaryFactory from '../../factories/beneficiary';
 import CommunityFactory from '../../factories/community';
+import ManagerFactory from '../../factories/manager';
 import UserFactory from '../../factories/user';
 import truncate, { sequelizeSetup } from '../../utils/sequelizeSetup';
-import ManagerFactory from '../../factories/manager';
 
 // in this test there are users being assined with suspicious activity and others being removed
 describe('community service', () => {
@@ -281,9 +281,9 @@ describe('community service', () => {
 
                 const result = await CommunityService.list({});
 
-                result.rows.forEach(el => {
-                    expect(el.email).to.be.undefined
-                })
+                result.rows.forEach((el) => {
+                    expect(el.email).to.be.undefined;
+                });
             });
         });
 
@@ -1064,7 +1064,7 @@ describe('community service', () => {
                     coverMediaId: 1,
                     email: 'test@gmail.com',
                 },
-                users[0].address,
+                users[0].address
             );
 
             expect(updatedCommunity.description).to.be.equal(
@@ -1072,7 +1072,7 @@ describe('community service', () => {
             );
             expect(updatedCommunity.coverMediaId).to.be.equal(1);
             expect(updatedCommunity.email).to.be.equal('test@gmail.com');
-        })
+        });
     });
 
     describe('promoter', () => {
@@ -1157,7 +1157,10 @@ describe('community service', () => {
 
             await ManagerFactory([users[0]], communities[0].publicId);
 
-            const result = await CommunityService.findById(communities[0].id, users[0].address);
+            const result = await CommunityService.findById(
+                communities[0].id,
+                users[0].address
+            );
 
             expect(result.publicId).to.be.equal(communities[0].publicId);
             expect(result.email).to.be.equal(communities[0].email);
@@ -1183,7 +1186,10 @@ describe('community service', () => {
 
             await ManagerFactory([users[0]], communities[0].publicId);
 
-            const result = await CommunityService.findById(communities[0].id, users[1].address);
+            const result = await CommunityService.findById(
+                communities[0].id,
+                users[1].address
+            );
 
             expect(result.publicId).to.be.equal(communities[0].publicId);
             expect(result.email).to.be.equal('');
@@ -1209,7 +1215,10 @@ describe('community service', () => {
 
             await ManagerFactory([users[0]], communities[0].publicId);
 
-            const result = await CommunityService.findByContractAddress(communities[0].contractAddress!, users[0].address);
+            const result = await CommunityService.findByContractAddress(
+                communities[0].contractAddress!,
+                users[0].address
+            );
 
             expect(result.publicId).to.be.equal(communities[0].publicId);
             expect(result.email).to.be.equal(communities[0].email);
@@ -1235,7 +1244,10 @@ describe('community service', () => {
 
             await ManagerFactory([users[0]], communities[0].publicId);
 
-            const result = await CommunityService.findByContractAddress(communities[0].contractAddress!, users[1].address);
+            const result = await CommunityService.findByContractAddress(
+                communities[0].contractAddress!,
+                users[1].address
+            );
 
             expect(result.publicId).to.be.equal(communities[0].publicId);
             expect(result.email).to.be.equal('');

--- a/tests/integration/services/community.test.ts
+++ b/tests/integration/services/community.test.ts
@@ -1137,7 +1137,7 @@ describe('community service', () => {
             await truncate(sequelize);
         });
 
-        it('find by id - manager search', async () => {
+        it('find by id - manager request', async () => {
             const communities = await CommunityFactory([
                 {
                     requestByAddress: users[0].address,
@@ -1163,7 +1163,7 @@ describe('community service', () => {
             expect(result.email).to.be.equal(communities[0].email);
         });
 
-        it('find by id - common user search', async () => {
+        it('find by id - common user request', async () => {
             const communities = await CommunityFactory([
                 {
                     requestByAddress: users[0].address,
@@ -1189,7 +1189,7 @@ describe('community service', () => {
             expect(result.email).to.be.equal('');
         });
 
-        it('find by Contract Address - manager search', async () => {
+        it('find by Contract Address - manager request', async () => {
             const communities = await CommunityFactory([
                 {
                     requestByAddress: users[0].address,
@@ -1215,7 +1215,7 @@ describe('community service', () => {
             expect(result.email).to.be.equal(communities[0].email);
         });
 
-        it('find by Contract Address - common user search', async () => {
+        it('find by Contract Address - common user request', async () => {
             const communities = await CommunityFactory([
                 {
                     requestByAddress: users[0].address,


### PR DESCRIPTION
This PR fixes [IPCT1-364] at https://impactmarket.atlassian.net/browse/IPCT1-364

## Changes
- changed findById and findByContractAddress to receive the authToken optionally, and with this token check if it is a manager request to return or not the community email.
- added a exclude clause in the list community service to don't return the community email.
- removed from the community model the config that hides the email.
- changed the edit endpoint to update the community email.

## New

<!---
Specify what's new. New endpoints, etc.
-->

## Tests
added tests on community.test.ts, to validate if the community email is not returned to common users, and returned to managers.