### PR TITLE
[IPCT1-504] verify if address is a merkle tree

### DIFF
--- a/src/worker/jobs/cron/filters/merkleTree.ts
+++ b/src/worker/jobs/cron/filters/merkleTree.ts
@@ -1,0 +1,30 @@
+import config from 'config';
+import { providers, Contract } from 'ethers';
+
+/**
+ * Returned addresses are merkle trees.
+ * @returns {Promise<string[]>}
+ */
+export async function filterMerkleTree(addresses: string[]): Promise<string[]> {
+    const MerkleABI = [
+        {
+            type: 'function',
+            stateMutability: 'view',
+            outputs: [{ type: 'bytes32', name: '', internalType: 'bytes32' }],
+            name: 'merkleRoot',
+            inputs: [],
+        },
+    ];
+    const provider = new providers.JsonRpcProvider(config.jsonRpcUrl);
+    const trees: string[] = [];
+    for (let index = 0; index < addresses.length; index++) {
+        const merkle = new Contract(addresses[index], MerkleABI, provider);
+        try {
+            await merkle.merkleRoot();
+            trees.push(addresses[index]);
+        } catch (_) {
+            // Merkle tree not found
+        }
+    }
+    return trees;
+}


### PR DESCRIPTION
This PR fixes [IPCT1-504] at https://impactmarket.atlassian.net/browse/IPCT1-504

## Changes
Adds a new method to be reused in other parts of the code.

## New
The new method filtres a list of addresses, returning only the ones that are merkleTrees.

## Tests
TBA