### PR TITLE
fix app_user migration

### DIFF
--- a/src/database/migrations/z1603324800-create-appUser.js
+++ b/src/database/migrations/z1603324800-create-appUser.js
@@ -1,19 +1,19 @@
 'use strict';
 module.exports = {
     up: (queryInterface, Sequelize) => {
-        return queryInterface.createTable('user', {
+        return queryInterface.createTable('app_user', {
+            id: {
+                type: Sequelize.INTEGER,
+                autoIncrement: true,
+                primaryKey: true,
+            },
             address: {
                 type: Sequelize.STRING(44),
-                primaryKey: true,
                 allowNull: false,
+                unique: true,
             },
             avatarMediaId: {
                 type: Sequelize.INTEGER,
-                // references: {
-                //     model: 'app_media_content',
-                //     key: 'id',
-                // },
-                // // onDelete: 'SET NULL', // default
                 allowNull: true,
             },
             username: {
@@ -74,6 +74,6 @@ module.exports = {
         });
     },
     down: (queryInterface, Sequelize) => {
-        return queryInterface.dropTable('user');
+        return queryInterface.dropTable('app_user');
     },
 };

--- a/src/database/migrations/z1615057322-create-appUserDevice.js
+++ b/src/database/migrations/z1615057322-create-appUserDevice.js
@@ -10,7 +10,7 @@ module.exports = {
             userAddress: {
                 type: Sequelize.STRING(44),
                 references: {
-                    model: 'user',
+                    model: 'app_user',
                     key: 'address',
                 },
                 onDelete: 'CASCADE',

--- a/src/database/migrations/z1615981221-create-appUserThroughTrust.js
+++ b/src/database/migrations/z1615981221-create-appUserThroughTrust.js
@@ -5,7 +5,7 @@ module.exports = {
             userAddress: {
                 type: Sequelize.STRING(44),
                 references: {
-                    model: 'user',
+                    model: 'app_user',
                     key: 'address',
                 },
                 onDelete: 'CASCADE',

--- a/src/database/migrations/z1619697064-create-storyContent.js
+++ b/src/database/migrations/z1619697064-create-storyContent.js
@@ -26,7 +26,7 @@ module.exports = {
             byAddress: {
                 type: Sequelize.STRING(44),
                 references: {
-                    model: 'user',
+                    model: 'app_user',
                     key: 'address',
                 },
                 onDelete: 'CASCADE',

--- a/src/database/migrations/z1619697067-create-storyUserEngagement.js
+++ b/src/database/migrations/z1619697067-create-storyUserEngagement.js
@@ -22,7 +22,7 @@ module.exports = {
             address: {
                 type: Sequelize.STRING(44),
                 references: {
-                    model: 'user',
+                    model: 'app_user',
                     key: 'address',
                 },
                 onDelete: 'CASCADE',

--- a/src/database/migrations/z1631138691-create-notification.js
+++ b/src/database/migrations/z1631138691-create-notification.js
@@ -12,7 +12,7 @@ module.exports = {
             address: {
                 type: Sequelize.STRING(44),
                 references: {
-                    model: 'user',
+                    model: 'app_user',
                     key: 'address',
                 },
                 onDelete: 'CASCADE',


### PR DESCRIPTION
## Changes
I can't do the `insert` into app_user directly, because the order of the columns is different in each environment (local, staging, production).
So, I changed the migration to get the columns dynamically. First, get the columns of the `user` table, and then, make an insert using this columns.

I tried to do it as simples as possible, but, what do you think @obernardovieira ?

## New

<!---
Specify what's new. New endpoints, etc.
-->

## Tests

<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->