### PR TITLE
[IPCT1-523] fix suspect level

### DIFF
--- a/src/worker/jobs/cron/community.ts
+++ b/src/worker/jobs/cron/community.ts
@@ -59,8 +59,10 @@ export async function verifyCommunitySuspectActivity(): Promise<void> {
                     : (suspectBeneficiaries.length /
                           community.beneficiaries.length) *
                       100;
-            const y = 60 * Math.log(ps + 1);
-            const suspectLevel = Math.round(Math.min(y, 100) / 10);
+            // The Math.log() function returns the natural logarithm (base e) of a number.
+            // The Math.log10() function returns the base 10 logarithm of a number.
+            const y = 60 * Math.log10(ps + 1);
+            const suspectLevel = Math.max(1, Math.round(Math.min(y, 100) / 10));
             // save suspect level
             await models.ubiCommunitySuspect.create(
                 {

--- a/tests/factories/community.ts
+++ b/tests/factories/community.ts
@@ -14,10 +14,10 @@ import {
 
 interface ICreateProps {
     requestByAddress: string;
-    started: Date;
-    status: 'pending' | 'valid' | 'removed';
-    visibility: 'public' | 'private';
-    contract: UbiCommunityContractCreation;
+    started?: Date;
+    status?: 'pending' | 'valid' | 'removed';
+    visibility?: 'public' | 'private';
+    contract?: UbiCommunityContractCreation;
     hasAddress?: boolean;
     name?: string;
     country?: string;
@@ -50,6 +50,18 @@ const data = async (props: ICreateProps) => {
         language: 'pt',
         name: props.name ? props.name : faker.company.companyName(),
         coverMediaId: 0,
+        started: props.started ? props.started : new Date(),
+        status: props.status ? props.status : 'valid',
+        visibility: props.visibility ? props.visibility : 'public',
+        contract: props.contract
+            ? props.contract
+            : {
+                  baseInterval: 60 * 60 * 24,
+                  claimAmount: '1000000000000000000',
+                  communityId: 0,
+                  incrementInterval: 5 * 60,
+                  maxClaim: '450000000000000000000',
+              },
         ...props,
     };
     if (props.hasAddress) {
@@ -71,9 +83,12 @@ const data = async (props: ICreateProps) => {
 const CommunityFactory = async (props: ICreateProps[]) => {
     const result: CommunityAttributes[] = [];
     for (let index = 0; index < props.length; index++) {
-        const newCommunity = await Community.create(await data(props[index]));
+        const communityData = await data(props[index]);
+        const newCommunity = await Community.create(communityData);
         const newContract = await UbiCommunityContractModel.create({
-            ...props[index].contract,
+            ...(props[index].contract
+                ? props[index].contract
+                : communityData.contract),
             communityId: newCommunity.id,
         });
         result.push({

--- a/tests/integration/jobs/cron/verifyCommunitySuspectActivity.test.ts
+++ b/tests/integration/jobs/cron/verifyCommunitySuspectActivity.test.ts
@@ -1,373 +1,156 @@
 import { Sequelize } from 'sequelize';
-import { stub, assert, match } from 'sinon';
+import Sinon, { stub, assert } from 'sinon';
 
 import { models } from '../../../../src/database';
 import { CommunityAttributes } from '../../../../src/database/models/ubi/community';
-import { AppUserTrust } from '../../../../src/interfaces/app/appUserTrust';
+import { AppUser } from '../../../../src/interfaces/app/appUser';
 import { verifyCommunitySuspectActivity } from '../../../../src/worker/jobs/cron/community';
+import BeneficiaryFactory from '../../../factories/beneficiary';
+import CommunityFactory from '../../../factories/community';
+import UserFactory from '../../../factories/user';
 import truncate, { sequelizeSetup } from '../../../utils/sequelizeSetup';
 
-// in this test there are 3 communities
-// onw with past suspicious activities, not having anymore
-// one without suspicious activity
-// one with new suspicious activity
 describe('[jobs - cron] verifyCommunitySuspectActivity', () => {
     let sequelize: Sequelize;
+    let users: AppUser[];
+    let communities: CommunityAttributes[];
+
+    let ubiCommunitySuspectAddStub: Sinon.SinonStub<any, Promise<void>>;
+
     before(async () => {
         sequelize = sequelizeSetup();
+        await sequelize.sync();
 
-        const yesterday = new Date();
-        yesterday.setDate(yesterday.getDate() - 1);
-        const twoMonthsAgo = new Date();
-        twoMonthsAgo.setDate(twoMonthsAgo.getDate() - 60);
-
-        const communities = await sequelize.models.Community.bulkCreate([
-            {
-                // previous suspicious activity removed
-                publicId: 'dd70a786-a2af-4c50-8d9c-6472bdb3dfdb',
-                requestByAddress: '0x012D33893983E187814Be1bdBe9852299829C554',
-                contractAddress: '0x602B9a3a16ad1Ce9a20878a28e3B1eD92D8eDb32',
-                name: '',
-                description: '',
-                city: '',
-                country: '',
-                gps: { latitude: 0, longitude: 0 },
-                email: '',
-                visibility: 'public',
-                coverImage: '',
-                coverMediaId: 0,
-                status: 'valid',
-                createdAt: new Date(),
-                updatedAt: new Date(),
-                currency: '',
-                descriptionEn: null,
-                language: '',
-                started: twoMonthsAgo,
-            },
-            {
-                // no suspicious activity
-                publicId: '073ddf28-4a3d-4e05-8570-ff38b656b46f',
-                requestByAddress: '0x002D33893983E187814Be1bdBe9852299829C554',
-                contractAddress: '0x592B9a3a16ad1Ce9a20878a28e3B1eD92D8eDb32',
-                name: '',
-                description: '',
-                city: '',
-                country: '',
-                gps: { latitude: 0, longitude: 0 },
-                email: '',
-                visibility: 'public',
-                coverImage: '',
-                coverMediaId: 0,
-                status: 'valid',
-                createdAt: new Date(),
-                updatedAt: new Date(),
-                currency: '',
-                descriptionEn: null,
-                language: '',
-                started: twoMonthsAgo,
-            },
-            {
-                // suspicious activity
-                publicId: '173ddf28-4a3d-4e05-8570-ff38b656b46f',
-                requestByAddress: '0x102D33893983E187814Be1bdBe9852299829C554',
-                contractAddress: '0x692B9a3a16ad1Ce9a20878a28e3B1eD92D8eDb32',
-                name: '',
-                description: '',
-                city: '',
-                country: '',
-                gps: { latitude: 0, longitude: 0 },
-                email: '',
-                visibility: 'public',
-                coverImage: '',
-                coverMediaId: 0,
-                status: 'valid',
-                createdAt: new Date(),
-                updatedAt: new Date(),
-                currency: '',
-                descriptionEn: null,
-                language: '',
-                started: twoMonthsAgo,
-            },
-        ]);
-
-        await sequelize.models.AppUserModel.bulkCreate([
-            {
-                address: '0xd55Fae4769e3240FfFf4c17cd2CC03143e55E420',
-                username: 'x1',
-                language: 'pt',
-                currency: 'BTC',
-                pushNotificationToken: '',
-                createdAt: new Date(),
-                updatedAt: new Date(),
-                suspect: true,
-            },
-            {
-                address: '0x002D33893983E187814Be1bdBe9852299829C554',
-                username: 'x1',
-                language: 'pt',
-                currency: 'BTC',
-                pushNotificationToken: '',
-                createdAt: new Date(),
-                updatedAt: new Date(),
-                suspect: true,
-            },
-            {
-                address: '0x012D33893983E187814Be1bdBe9852299829C554',
-                username: 'x1',
-                language: 'pt',
-                currency: 'BTC',
-                pushNotificationToken: '',
-                createdAt: new Date(),
-                updatedAt: new Date(),
-                suspect: false,
-            },
-            {
-                address: '0xc55Fae4769e3240FfFf4c17cd2CC03143e55E420',
-                username: 'x1',
-                language: 'pt',
-                currency: 'BTC',
-                pushNotificationToken: '',
-                createdAt: new Date(),
-                updatedAt: new Date(),
-                suspect: false,
-            },
-            {
-                address: '0x102D33893983E187814Be1bdBe9852299829C554',
-                username: 'x1',
-                language: 'pt',
-                currency: 'BTC',
-                pushNotificationToken: '',
-                createdAt: new Date(),
-                updatedAt: new Date(),
-                suspect: false,
-            },
-            {
-                address: '0xb55Fae4769e3240FfFf4c17cd2CC03143e55E420',
-                username: 'x1',
-                language: 'pt',
-                currency: 'BTC',
-                pushNotificationToken: '',
-                createdAt: new Date(),
-                updatedAt: new Date(),
-                suspect: true,
-            },
-            {
-                address: '0x202D33893983E187814Be1bdBe9852299829C554',
-                username: 'x1',
-                language: 'pt',
-                currency: 'BTC',
-                pushNotificationToken: '',
-                createdAt: new Date(),
-                updatedAt: new Date(),
-                suspect: false,
-            },
-        ]);
-
-        const r = await sequelize.models.AppUserTrustModel.bulkCreate([
-            {
-                phone: '00351969696966',
-                verifiedPhoneNumber: false,
-            },
-            {
-                phone: '00351969696966',
-                verifiedPhoneNumber: false,
-            },
-            {
-                phone: '00351969696967',
-                verifiedPhoneNumber: false,
-            },
-            {
-                phone: '00351969696968',
-                verifiedPhoneNumber: false,
-            },
-            {
-                phone: '00351969696969',
-                verifiedPhoneNumber: false,
-            },
-            {
-                phone: '00351979696966',
-                verifiedPhoneNumber: false,
-            },
-            {
-                phone: '00351989696966',
-                verifiedPhoneNumber: false,
-            },
-        ]);
-        const tIds = r.map((ids) => ids.toJSON() as AppUserTrust);
-
-        await sequelize.models.AppUserThroughTrustModel.bulkCreate([
-            {
-                userAddress: '0xd55Fae4769e3240FfFf4c17cd2CC03143e55E420',
-                appUserTrustId: tIds[0].id,
-            },
-            {
-                userAddress: '0x002D33893983E187814Be1bdBe9852299829C554',
-                appUserTrustId: tIds[1].id,
-            },
-            {
-                userAddress: '0x012D33893983E187814Be1bdBe9852299829C554',
-                appUserTrustId: tIds[2].id,
-            },
-            {
-                userAddress: '0xc55Fae4769e3240FfFf4c17cd2CC03143e55E420',
-                appUserTrustId: tIds[3].id,
-            },
-            {
-                userAddress: '0x102D33893983E187814Be1bdBe9852299829C554',
-                appUserTrustId: tIds[4].id,
-            },
-            {
-                userAddress: '0xb55Fae4769e3240FfFf4c17cd2CC03143e55E420',
-                appUserTrustId: tIds[5].id,
-            },
-            {
-                userAddress: '0x202D33893983E187814Be1bdBe9852299829C554',
-                appUserTrustId: tIds[6].id,
-            },
-        ]);
-
-        await sequelize.models.Beneficiary.bulkCreate([
-            {
-                address: '0xb55Fae4769e3240FfFf4c17cd2CC03143e55E420',
-                communityId: 'dd70a786-a2af-4c50-8d9c-6472bdb3dfdb',
-                txAt: new Date(),
-                claims: 3,
-                lastClaimAt: null,
-                penultimateClaimAt: null,
-                active: false,
-                blocked: false,
-                tx: '0xa56148b8a8c559bc52e438a8d50afc5c1f68201a07c6c67615d1e2da00999f5b',
-                createdAt: new Date(),
-                updatedAt: new Date(),
-            },
-            {
-                address: '0x202D33893983E187814Be1bdBe9852299829C554',
-                communityId: 'dd70a786-a2af-4c50-8d9c-6472bdb3dfdb',
-                txAt: new Date(),
-                claims: 2,
-                lastClaimAt: null,
-                penultimateClaimAt: null,
-                active: true,
-                blocked: false,
-                tx: '0xaf364783a779a9787ec590a3b40ba53915713c8c10315f98740819321b3423d9',
-                createdAt: new Date(),
-                updatedAt: new Date(),
-            },
-            {
-                address: '0xd55Fae4769e3240FfFf4c17cd2CC03143e55E420',
-                communityId: '073ddf28-4a3d-4e05-8570-ff38b656b46f',
-                txAt: new Date(),
-                claims: 0,
-                lastClaimAt: null,
-                penultimateClaimAt: null,
-                active: true,
-                blocked: false,
-                tx: '0xb56148b8a8c559bc52e438a8d50afc5c1f68201a07c6c67615d1e2da00999f5b',
-                createdAt: new Date(),
-                updatedAt: new Date(),
-            },
-            {
-                address: '0x002D33893983E187814Be1bdBe9852299829C554',
-                communityId: '073ddf28-4a3d-4e05-8570-ff38b656b46f',
-                txAt: new Date(),
-                claims: 0,
-                lastClaimAt: null,
-                penultimateClaimAt: null,
-                active: false,
-                blocked: false,
-                tx: '0xef364783a779a9787ec590a3b40ba53915713c8c10315f98740819321b3423d9',
-                createdAt: new Date(),
-                updatedAt: new Date(),
-            },
-            {
-                address: '0x012D33893983E187814Be1bdBe9852299829C554',
-                communityId: '073ddf28-4a3d-4e05-8570-ff38b656b46f',
-                txAt: new Date(),
-                claims: 0,
-                lastClaimAt: null,
-                penultimateClaimAt: null,
-                active: true,
-                blocked: false,
-                tx: '0xef464783a779a9787ec590a3b40ba53915713c8c10315f98740819321b3423d9',
-                createdAt: new Date(),
-                updatedAt: new Date(),
-            },
-            {
-                address: '0xc55Fae4769e3240FfFf4c17cd2CC03143e55E420',
-                communityId: '173ddf28-4a3d-4e05-8570-ff38b656b46f',
-                txAt: new Date(),
-                claims: 0,
-                lastClaimAt: null,
-                penultimateClaimAt: null,
-                active: true,
-                blocked: false,
-                tx: '0xc56148b8a8c559bc52e438a8d50afc5c1f68201a07c6c67615d1e2da00999f5b',
-                createdAt: new Date(),
-                updatedAt: new Date(),
-            },
-            {
-                address: '0x102D33893983E187814Be1bdBe9852299829C554',
-                communityId: '173ddf28-4a3d-4e05-8570-ff38b656b46f',
-                txAt: new Date(),
-                claims: 0,
-                lastClaimAt: null,
-                penultimateClaimAt: null,
-                active: false,
-                blocked: false,
-                tx: '0xcf364783a779a9787ec590a3b40ba53915713c8c10315f98740819321b3423d9',
-                createdAt: new Date(),
-                updatedAt: new Date(),
-            },
-        ]);
-
-        const rCommunities = communities.map(
-            (ids) => ids.toJSON() as CommunityAttributes
-        );
-
-        await sequelize.models.UbiCommunitySuspectModel.bulkCreate([
-            {
-                communityId: rCommunities[0].id,
-                percentage: 50,
-                suspect: 10,
-                createdAt: yesterday,
-            },
-        ]);
+        ubiCommunitySuspectAddStub = stub(models.ubiCommunitySuspect, 'create');
+        ubiCommunitySuspectAddStub.returns(Promise.resolve());
     });
 
     after(async () => {
-        await sequelize.models.Beneficiary.destroy({
-            where: {},
-        });
-        await sequelize.models.AppUserThroughTrustModel.destroy({
-            where: {},
-        });
-        await sequelize.models.AppUserTrustModel.destroy({
-            where: {},
-        });
-        await sequelize.models.AppUserModel.destroy({
-            where: {},
-        });
-        await sequelize.models.Community.destroy({
-            where: {},
-        });
+        await truncate(sequelize, 'Beneficiary');
+        await truncate(sequelize);
     });
 
-    it('with suspicious activity', async () => {
-        const ubiCommunitySuspectAddStub = stub(
-            models.ubiCommunitySuspect,
-            'create'
-        );
-        ubiCommunitySuspectAddStub.returns(Promise.resolve({} as any));
+    beforeEach(async () => {
+        await truncate(sequelize, 'Beneficiary');
+        await truncate(sequelize, 'Community');
+        ubiCommunitySuspectAddStub.reset();
+    });
+
+    it('with 100% (level 10) suspicious activity', async () => {
+        users = await UserFactory({
+            n: 5,
+            props: Array(5).fill({ suspect: true }),
+        });
+        communities = await CommunityFactory([
+            {
+                requestByAddress: users[0].address,
+                hasAddress: true,
+            },
+        ]);
+        await BeneficiaryFactory(users, communities[0].publicId);
+
         await verifyCommunitySuspectActivity();
         assert.callCount(ubiCommunitySuspectAddStub, 1);
         assert.calledWith(
             ubiCommunitySuspectAddStub.getCall(0),
             {
-                communityId: match.any,
+                communityId: communities[0].id,
+                percentage: 100,
+                suspect: 10,
+            },
+            { returning: false }
+        );
+    });
+
+    it('with 1% (level 2) suspicious activity', async () => {
+        users = await UserFactory({
+            n: 100,
+            props: Array(1).fill({ suspect: true }),
+        });
+        communities = await CommunityFactory([
+            {
+                requestByAddress: users[0].address,
+                hasAddress: true,
+            },
+        ]);
+        await BeneficiaryFactory(users, communities[0].publicId);
+
+        await verifyCommunitySuspectActivity();
+        assert.callCount(ubiCommunitySuspectAddStub, 1);
+        assert.calledWith(
+            ubiCommunitySuspectAddStub.getCall(0),
+            {
+                communityId: communities[0].id,
+                percentage: 1,
+                suspect: 2,
+            },
+            { returning: false }
+        );
+    });
+
+    it('with 14.29% (level 7) suspicious activity', async () => {
+        users = await UserFactory({
+            n: 35,
+            props: Array(5).fill({ suspect: true }),
+        });
+        communities = await CommunityFactory([
+            {
+                requestByAddress: users[0].address,
+                hasAddress: true,
+            },
+        ]);
+        await BeneficiaryFactory(users, communities[0].publicId);
+
+        await verifyCommunitySuspectActivity();
+        assert.callCount(ubiCommunitySuspectAddStub, 1);
+        assert.calledWith(
+            ubiCommunitySuspectAddStub.getCall(0),
+            {
+                communityId: communities[0].id,
+                percentage: 14.29,
+                suspect: 7,
+            },
+            { returning: false }
+        );
+    });
+
+    it('with 50% (level 10) suspicious activity', async () => {
+        users = await UserFactory({
+            n: 10,
+            props: Array(5).fill({ suspect: true }),
+        });
+        communities = await CommunityFactory([
+            {
+                requestByAddress: users[0].address,
+                hasAddress: true,
+            },
+        ]);
+        await BeneficiaryFactory(users, communities[0].publicId);
+
+        await verifyCommunitySuspectActivity();
+        assert.callCount(ubiCommunitySuspectAddStub, 1);
+        assert.calledWith(
+            ubiCommunitySuspectAddStub.getCall(0),
+            {
+                communityId: communities[0].id,
                 percentage: 50,
                 suspect: 10,
             },
             { returning: false }
         );
+    });
+
+    it('without suspicious activity', async () => {
+        users = await UserFactory({ n: 10 });
+        communities = await CommunityFactory([
+            {
+                requestByAddress: users[0].address,
+                hasAddress: true,
+            },
+        ]);
+        await BeneficiaryFactory(users, communities[0].publicId);
+
+        await verifyCommunitySuspectActivity();
+        assert.callCount(ubiCommunitySuspectAddStub, 0);
     });
 });


### PR DESCRIPTION
This PR fixes [IPCT1-523] at https://impactmarket.atlassian.net/browse/IPCT1-523

## Changes
the suspect level calculation was using log with base e, instead of log with base 10, resulting in wrong levels.

## Tests

Tests for community suspicious level were totally refactored, with new use cases.