### PR TITLE
[IPCT1-542] - refactor community list

### DIFF
--- a/src/api/controllers/community.ts
+++ b/src/api/controllers/community.ts
@@ -247,7 +247,7 @@ class CommunityController {
             email,
             txReceipt,
             contractParams,
-            coverMediaId
+            coverMediaId,
         })
             .then((community) => standardResponse(res, 201, true, community))
             .catch((e) => standardResponse(res, 400, false, '', { error: e }));

--- a/src/database/models/ubi/community.ts
+++ b/src/database/models/ubi/community.ts
@@ -7,9 +7,10 @@ import { UbiCommunityDailyState } from '@interfaces/ubi/ubiCommunityDailyState';
 import { UbiCommunityDemographics } from '@interfaces/ubi/ubiCommunityDemographics';
 import { UbiCommunityState } from '@interfaces/ubi/ubiCommunityState';
 import { UbiCommunitySuspect } from '@interfaces/ubi/ubiCommunitySuspect';
+import { Sequelize, DataTypes, Model } from 'sequelize';
+
 import { ICommunityContractParams } from '../../../types';
 // import { UbiPromoter } from '@interfaces/ubi/ubiPromoter';
-import { Sequelize, DataTypes, Model } from 'sequelize';
 
 import { BeneficiaryAttributes } from './beneficiary';
 
@@ -72,8 +73,7 @@ export interface CommunityAttributes {
     demographics?: UbiCommunityDemographics[]; // TODO: to be removed
     dailyState?: UbiCommunityDailyState[]; // TODO: to be removed
 }
-export interface ICommunityCreationAttributes
-    extends IBaseCommunityAttributes {
+export interface ICommunityCreationAttributes extends IBaseCommunityAttributes {
     descriptionEn?: string;
     visibility?: 'public' | 'private';
     coverImage?: string; // TODO: will be required once next version is released

--- a/src/services/ubi/community.ts
+++ b/src/services/ubi/community.ts
@@ -315,10 +315,6 @@ export default class CommunityService {
         fields?: string;
         status?: 'valid' | 'pending';
     }): Promise<{ count: number; rows: CommunityAttributes[] }> {
-        if(!query.status) {
-            query.status = 'valid';
-        }
-
         let extendedWhere: WhereOptions<CommunityAttributes> = {};
         const orderOption: OrderItem[] = [];
 
@@ -447,7 +443,7 @@ export default class CommunityService {
         const communitiesResult = await this.community.findAndCountAll({
             attributes,
             where: {
-                status: query.status,
+                status: query.status ? query.status : 'valid',
                 visibility: 'public',
                 ...extendedWhere,
             },

--- a/src/services/ubi/community.ts
+++ b/src/services/ubi/community.ts
@@ -426,20 +426,20 @@ export default class CommunityService {
         let include: Includeable[];
         let attributes: any;
         const exclude = ['email'];
-        if(query.fields) {
+        if (query.fields) {
             const fields = fetchData(query.fields);
             include = this._generateInclude(fields);
-            attributes = fields.root && fields.root.length > 0
-            ?  fields.root.filter((el: string) => !exclude.includes(el))  
-            : [];
+            attributes =
+                fields.root && fields.root.length > 0
+                    ? fields.root.filter((el: string) => !exclude.includes(el))
+                    : [];
         } else {
             include = this._oldInclude(query.extended);
             attributes = {
                 exclude,
-            }
+            };
         }
 
-        
         const communitiesResult = await this.community.findAndCountAll({
             attributes,
             where: {
@@ -449,8 +449,12 @@ export default class CommunityService {
             },
             include,
             order: orderOption,
-            offset: query.offset ? parseInt(query.offset, 10) : config.defaultOffset,
-            limit: query.limit ? parseInt(query.limit, 10) : config.defaultLimit,
+            offset: query.offset
+                ? parseInt(query.offset, 10)
+                : config.defaultOffset,
+            limit: query.limit
+                ? parseInt(query.limit, 10)
+                : config.defaultLimit,
         });
 
         const communities = communitiesResult.rows.map((c) =>
@@ -1546,10 +1550,11 @@ export default class CommunityService {
 
     private static _generateInclude(fields: any): Includeable[] {
         const extendedInclude: Includeable[] = [];
-        if(fields.suspect) {
+        if (fields.suspect) {
             extendedInclude.push({
                 model: this.ubiCommunitySuspect,
-                attributes: fields.suspect.length > 0 ? fields.suspect : undefined,
+                attributes:
+                    fields.suspect.length > 0 ? fields.suspect : undefined,
                 as: 'suspect',
                 required: false,
                 duplicating: false,
@@ -1560,10 +1565,10 @@ export default class CommunityService {
                         ),
                     },
                 },
-            })
+            });
         }
 
-        if(fields.cover || fields.thumbnails) {
+        if (fields.cover || fields.thumbnails) {
             extendedInclude.push({
                 attributes: fields.cover
                     ? fields.cover.length > 0
@@ -1573,28 +1578,35 @@ export default class CommunityService {
                 model: this.appMediaContent,
                 as: 'cover',
                 duplicating: false,
-                include: fields.thumbnails ? [
-                    {
-                        attributes: fields.thumbnails.length > 0 ? fields.thumbnails : undefined,
-                        model: this.appMediaThumbnail,
-                        as: 'thumbnails',
-                        separate: true,
-                    },
-                ] : [],
-            })
+                include: fields.thumbnails
+                    ? [
+                          {
+                              attributes:
+                                  fields.thumbnails.length > 0
+                                      ? fields.thumbnails
+                                      : undefined,
+                              model: this.appMediaThumbnail,
+                              as: 'thumbnails',
+                              separate: true,
+                          },
+                      ]
+                    : [],
+            });
         }
 
-        if(fields.contract) {
+        if (fields.contract) {
             extendedInclude.push({
-                attributes: fields.contract.length > 0 ? fields.contract : undefined,
+                attributes:
+                    fields.contract.length > 0 ? fields.contract : undefined,
                 model: this.ubiCommunityContract,
                 as: 'contract',
-            })
+            });
         }
 
-        if(fields.metrics) {
+        if (fields.metrics) {
             extendedInclude.push({
-                attributes: fields.metrics.length > 0 ? fields.metrics : undefined,
+                attributes:
+                    fields.metrics.length > 0 ? fields.metrics : undefined,
                 model: this.ubiCommunityDailyMetrics,
                 required: false,
                 duplicating: false,
@@ -1606,23 +1618,25 @@ export default class CommunityService {
                         ),
                     },
                 },
-            })
+            });
         }
 
         const stateExclude = ['id', 'communityId'];
-        let stateAttributes = fields.state
-        ?  fields.state.length > 0 
-            ? fields.state.filter((el: string) => !stateExclude.includes(el))  
-            : { exclude: stateExclude }
-        : []
+        const stateAttributes = fields.state
+            ? fields.state.length > 0
+                ? fields.state.filter(
+                      (el: string) => !stateExclude.includes(el)
+                  )
+                : { exclude: stateExclude }
+            : [];
         extendedInclude.push({
             model: this.ubiCommunityState,
             attributes: stateAttributes,
             as: 'state',
-        })
+        });
 
         return extendedInclude;
-    };
+    }
 
     private static _oldInclude(extended?: string): Includeable[] {
         const extendedInclude: Includeable[] = [];

--- a/src/services/ubi/community.ts
+++ b/src/services/ubi/community.ts
@@ -1569,25 +1569,20 @@ export default class CommunityService {
             });
         }
 
-        if (fields.cover || fields.thumbnails) {
+        if (fields.cover) {
             extendedInclude.push({
-                attributes: fields.cover
-                    ? fields.cover.length > 0
-                        ? fields.cover
-                        : undefined
-                    : ['id'],
+                attributes: ['url'],
                 model: this.appMediaContent,
                 as: 'cover',
                 duplicating: false,
-                include: fields.thumbnails
-                    ? [
-                          {
-                              model: this.appMediaThumbnail,
-                              as: 'thumbnails',
-                              separate: true,
-                          },
-                      ]
-                    : [],
+                include: [
+                      {
+                          attributes: ['url', 'width', 'height', 'pixelRatio'],
+                          model: this.appMediaThumbnail,
+                          as: 'thumbnails',
+                          separate: true,
+                      },
+                  ],
             });
         }
 

--- a/src/services/ubi/community.ts
+++ b/src/services/ubi/community.ts
@@ -1563,9 +1563,13 @@ export default class CommunityService {
             })
         }
 
-        if(fields.cover) {
+        if(fields.cover || fields.thumbnails) {
             extendedInclude.push({
-                attributes: fields.cover.length > 0 ? fields.cover : undefined,
+                attributes: fields.cover
+                    ? fields.cover.length > 0
+                        ? fields.cover
+                        : undefined
+                    : ['id'],
                 model: this.appMediaContent,
                 as: 'cover',
                 duplicating: false,
@@ -1606,8 +1610,10 @@ export default class CommunityService {
         }
 
         const stateExclude = ['id', 'communityId'];
-        let stateAttributes = fields.state && fields.state.length > 0
-        ?  fields.state.filter((el: string) => !stateExclude.includes(el))  
+        let stateAttributes = fields.state
+        ?  fields.state.length > 0 
+            ? fields.state.filter((el: string) => !stateExclude.includes(el))  
+            : { exclude: stateExclude }
         : []
         extendedInclude.push({
             model: this.ubiCommunityState,

--- a/src/services/ubi/community.ts
+++ b/src/services/ubi/community.ts
@@ -1582,10 +1582,6 @@ export default class CommunityService {
                 include: fields.thumbnails
                     ? [
                           {
-                              attributes:
-                                  fields.thumbnails.length > 0
-                                      ? fields.thumbnails
-                                      : undefined,
                               model: this.appMediaThumbnail,
                               as: 'thumbnails',
                               separate: true,

--- a/src/services/ubi/community.ts
+++ b/src/services/ubi/community.ts
@@ -1571,7 +1571,7 @@ export default class CommunityService {
 
         if (fields.cover) {
             extendedInclude.push({
-                attributes: ['url'],
+                attributes: ['id', 'url'],
                 model: this.appMediaContent,
                 as: 'cover',
                 duplicating: false,

--- a/src/services/ubi/community.ts
+++ b/src/services/ubi/community.ts
@@ -429,10 +429,11 @@ export default class CommunityService {
         if (query.fields) {
             const fields = fetchData(query.fields);
             include = this._generateInclude(fields);
-            attributes =
-                fields.root && fields.root.length > 0
+            attributes = fields.root 
+                ? fields.root.length > 0
                     ? fields.root.filter((el: string) => !exclude.includes(el))
-                    : [];
+                    : { exclude }
+                : []
         } else {
             include = this._oldInclude(query.extended);
             attributes = {

--- a/src/utils/dataFetching.ts
+++ b/src/utils/dataFetching.ts
@@ -1,0 +1,31 @@
+interface IField {
+    [key: string]: string[] | []
+}
+
+export const getFields = (queryString: string): IField => {
+    const fields = queryString.split(';');
+
+    const result = fields.reduce((acc, val) => {
+        const splitedValue = val.split('.');
+        if(splitedValue.length > 1) {
+            if(splitedValue[1] === '*') {
+                acc[splitedValue[0]] = [];
+            } else if(acc[splitedValue[0]]) {
+                (acc[splitedValue[0]] as string[]).push(splitedValue[1])
+            } else {
+                acc[splitedValue[0]] = [splitedValue[1]];
+            }
+        } else {
+            if(splitedValue[0] === '*') {
+                acc.root = [];
+            } else if(acc.root) {
+                (acc.root as string[]).push(splitedValue[0])
+            } else {
+                acc.root = splitedValue;
+            }
+        }
+        return acc;
+    }, {} as IField);
+
+    return result;
+}

--- a/src/utils/dataFetching.ts
+++ b/src/utils/dataFetching.ts
@@ -1,5 +1,5 @@
 interface IField {
-    [key: string]: string[] | []
+    [key: string]: string[] | [];
 }
 
 export const fetchData = (queryString: string): IField => {
@@ -7,21 +7,21 @@ export const fetchData = (queryString: string): IField => {
 
     const result = fields.reduce((acc, el) => {
         const value = el.trim();
-        if(value) {
+        if (value) {
             const splitedValue = value.split('.');
-            if(splitedValue.length > 1) {
-                if(splitedValue[1] === '*') {
+            if (splitedValue.length > 1) {
+                if (splitedValue[1] === '*') {
                     acc[splitedValue[0]] = [];
-                } else if(acc[splitedValue[0]]) {
-                    (acc[splitedValue[0]] as string[]).push(splitedValue[1])
+                } else if (acc[splitedValue[0]]) {
+                    (acc[splitedValue[0]] as string[]).push(splitedValue[1]);
                 } else {
                     acc[splitedValue[0]] = [splitedValue[1]];
                 }
             } else {
-                if(splitedValue[0] === '*') {
+                if (splitedValue[0] === '*') {
                     acc.root = [];
-                } else if(acc.root) {
-                    (acc.root as string[]).push(splitedValue[0])
+                } else if (acc.root) {
+                    (acc.root as string[]).push(splitedValue[0]);
                 } else {
                     acc.root = splitedValue;
                 }
@@ -31,4 +31,4 @@ export const fetchData = (queryString: string): IField => {
     }, {} as IField);
 
     return result;
-}
+};

--- a/src/utils/dataFetching.ts
+++ b/src/utils/dataFetching.ts
@@ -2,26 +2,29 @@ interface IField {
     [key: string]: string[] | []
 }
 
-export const getFields = (queryString: string): IField => {
+export const fetchData = (queryString: string): IField => {
     const fields = queryString.split(';');
 
-    const result = fields.reduce((acc, val) => {
-        const splitedValue = val.split('.');
-        if(splitedValue.length > 1) {
-            if(splitedValue[1] === '*') {
-                acc[splitedValue[0]] = [];
-            } else if(acc[splitedValue[0]]) {
-                (acc[splitedValue[0]] as string[]).push(splitedValue[1])
+    const result = fields.reduce((acc, el) => {
+        const value = el.trim();
+        if(value) {
+            const splitedValue = value.split('.');
+            if(splitedValue.length > 1) {
+                if(splitedValue[1] === '*') {
+                    acc[splitedValue[0]] = [];
+                } else if(acc[splitedValue[0]]) {
+                    (acc[splitedValue[0]] as string[]).push(splitedValue[1])
+                } else {
+                    acc[splitedValue[0]] = [splitedValue[1]];
+                }
             } else {
-                acc[splitedValue[0]] = [splitedValue[1]];
-            }
-        } else {
-            if(splitedValue[0] === '*') {
-                acc.root = [];
-            } else if(acc.root) {
-                (acc.root as string[]).push(splitedValue[0])
-            } else {
-                acc.root = splitedValue;
+                if(splitedValue[0] === '*') {
+                    acc.root = [];
+                } else if(acc.root) {
+                    (acc.root as string[]).push(splitedValue[0])
+                } else {
+                    acc.root = splitedValue;
+                }
             }
         }
         return acc;

--- a/tests/integration/services/community.test.ts
+++ b/tests/integration/services/community.test.ts
@@ -1062,7 +1062,7 @@ describe('community service', () => {
                 });
 
                 const result = await CommunityService.list({
-                    fields: 'id;publicId;contractAddress;contract.*;state.claimed;cover.id;thumbnails.*',
+                    fields: 'id;publicId;contractAddress;contract.*;state.claimed;cover.*',
                 });
 
                 expect(result.rows[0]).to.have.deep.keys([
@@ -1087,11 +1087,10 @@ describe('community service', () => {
                 ]);
                 expect(result.rows[0].cover).to.have.deep.keys([
                     'id',
+                    'url',
                     'thumbnails'
                 ]);
                 expect(result.rows[0].cover!.thumbnails![0]).to.have.deep.keys([
-                    'id',
-                    'mediaContentId',
                     'url',
                     'width',
                     'height',

--- a/tests/integration/services/community.test.ts
+++ b/tests/integration/services/community.test.ts
@@ -885,7 +885,7 @@ describe('community service', () => {
                 await truncate(sequelize, 'Community');
             });
 
-            it('filter fields on community list', async () => {
+            it('filter with specific fields', async () => {
                 const communities = await CommunityFactory([
                     {
                         requestByAddress: users[0].address,
@@ -908,7 +908,7 @@ describe('community service', () => {
                 ]);
 
                 const result = await CommunityService.list({
-                    fields: 'id;publicId;contract.maxClaim',
+                    fields: 'id;publicId;contract.maxClaim;contract.claimAmount',
                 });
 
                 expect(result.rows[0]).to.have.deep.keys([
@@ -916,12 +916,198 @@ describe('community service', () => {
                     'publicId',
                     'contract',
                 ]);
+                expect(result.rows[0].contract).to.have.deep.keys([
+                    'claimAmount',
+                    'maxClaim',
+                ]);
                 expect(result.rows[0]).to.include({
                     id: communities[0].id,
                     publicId: communities[0].publicId,
                 });
                 expect(result.rows[0].contract).to.include({
                     maxClaim: communities[0]!.contract!.maxClaim,
+                    claimAmount: communities[0]!.contract!.claimAmount
+                });
+            });
+
+            it('filter with grouped fields', async () => {
+                const communities = await CommunityFactory([
+                    {
+                        requestByAddress: users[0].address,
+                        started: new Date(),
+                        status: 'valid',
+                        visibility: 'public',
+                        contract: {
+                            baseInterval: 60 * 60 * 24,
+                            claimAmount: '1000000000000000000',
+                            communityId: 0,
+                            incrementInterval: 5 * 60,
+                            maxClaim: '450000000000000000000',
+                        },
+                        hasAddress: true,
+                        gps: {
+                            latitude: -23.4378873,
+                            longitude: -46.4841214,
+                        },
+                    },
+                ]);
+
+                const result = await CommunityService.list({
+                    fields: '*;contract.*',
+                });
+
+                expect(result.rows[0]).to.have.deep.keys([
+                    'city',
+                    'contract',
+                    'contractAddress',
+                    'country',
+                    'coverImage',
+                    'coverMediaId',
+                    'createdAt',
+                    'currency',
+                    'deletedAt',
+                    'description',
+                    'descriptionEn',
+                    'gps',
+                    'id',
+                    'language',
+                    'name',
+                    'publicId',
+                    'requestByAddress',
+                    'review',
+                    'started',
+                    'status',
+                    'updatedAt',
+                    'visibility'
+                ]);
+                expect(result.rows[0].contract).to.have.deep.keys([
+                    'claimAmount',
+                    'maxClaim',
+                    'baseInterval',
+                    'incrementInterval',
+                    'communityId',
+                    'createdAt',
+                    'updatedAt',
+                ]);
+                expect(result.rows[0]).to.include({
+                    id: communities[0].id,
+                    publicId: communities[0].publicId,
+                    city: communities[0].city,
+                    contractAddress: communities[0].contractAddress,
+                    country: communities[0].country,
+                    coverImage: communities[0].coverImage,
+                    coverMediaId: communities[0].coverMediaId,
+                    currency: communities[0].currency,
+                    description: communities[0].description,
+                    descriptionEn: communities[0].descriptionEn,
+                    language: communities[0].language,
+                    name: communities[0].name,
+                    requestByAddress: communities[0].requestByAddress,
+                    review: communities[0].review,
+                    started: communities[0].started,
+                    status: communities[0].status,
+                    visibility: communities[0].visibility
+                });
+                expect(result.rows[0].contract).to.include({
+                    maxClaim: communities[0]!.contract!.maxClaim,
+                    claimAmount: communities[0]!.contract!.claimAmount,
+                    baseInterval: communities[0]!.contract!.baseInterval,
+                    incrementInterval: communities[0]!.contract!.incrementInterval,
+                    communityId: communities[0]!.contract!.communityId,
+                });
+            });
+
+            it('filter with mixed fields', async () => {
+                const communities = await CommunityFactory([
+                    {
+                        requestByAddress: users[0].address,
+                        started: new Date(),
+                        status: 'valid',
+                        visibility: 'public',
+                        contract: {
+                            baseInterval: 60 * 60 * 24,
+                            claimAmount: '1000000000000000000',
+                            communityId: 0,
+                            incrementInterval: 5 * 60,
+                            maxClaim: '450000000000000000000',
+                        },
+                        hasAddress: true,
+                        gps: {
+                            latitude: -23.4378873,
+                            longitude: -46.4841214,
+                        },
+                    },
+                ]);
+
+                const media = await models.appMediaContent.create({
+                    url: 'test.com',
+                    width: 0,
+                    height: 0,
+                });
+
+                await models.appMediaThumbnail.create({
+                    mediaContentId: media.id,
+                    url: 'test.com',
+                    width: 0,
+                    height: 0,
+                    pixelRatio: 0,
+                })
+
+                await models.community.update({
+                    coverMediaId: media.id
+                }, {
+                    where: {
+                        id: communities[0].id
+                    }
+                });
+
+                const result = await CommunityService.list({
+                    fields: 'id;publicId;contractAddress;contract.*;state.claimed;cover.id;thumbnails.*',
+                });
+
+                expect(result.rows[0]).to.have.deep.keys([
+                    'id',
+                    'publicId',
+                    'contractAddress',
+                    'contract',
+                    'state',
+                    'cover',
+                ]);
+                expect(result.rows[0].contract).to.have.deep.keys([
+                    'claimAmount',
+                    'maxClaim',
+                    'baseInterval',
+                    'incrementInterval',
+                    'communityId',
+                    'createdAt',
+                    'updatedAt',
+                ]);
+                expect(result.rows[0].state).to.have.deep.keys([
+                    'claimed',
+                ]);
+                expect(result.rows[0].cover).to.have.deep.keys([
+                    'id',
+                    'thumbnails'
+                ]);
+                expect(result.rows[0].cover!.thumbnails![0]).to.have.deep.keys([
+                    'id',
+                    'mediaContentId',
+                    'url',
+                    'width',
+                    'height',
+                    'pixelRatio'
+                ]);
+                expect(result.rows[0]).to.include({
+                    id: communities[0].id,
+                    publicId: communities[0].publicId,
+                    contractAddress: communities[0].contractAddress,
+                });
+                expect(result.rows[0].contract).to.include({
+                    maxClaim: communities[0]!.contract!.maxClaim,
+                    claimAmount: communities[0]!.contract!.claimAmount,
+                    baseInterval: communities[0]!.contract!.baseInterval,
+                    incrementInterval: communities[0]!.contract!.incrementInterval,
+                    communityId: communities[0]!.contract!.communityId,
                 });
             });
 


### PR DESCRIPTION
This PR fixes [IPCT1-542] at https://impactmarket.atlassian.net/browse/IPCT1-542

## Changes
service list community changed to:
1 - enable user in a single endpoint filter the `valids` and `pendings` communities.
2- enable user to pass all the fields that he want, using a syntax close of SQL (`fields=id; publicId; contract.maxClaim; contract.baseInterval; state.*`)

## New

<!---
Specify what's new. New endpoints, etc.
-->

## Tests

<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->