### PR TITLE
[IPCT1-486] - update claimed and raised in community state

### DIFF
--- a/src/database/migrations/z1636472208-update-triggers.js
+++ b/src/database/migrations/z1636472208-update-triggers.js
@@ -1,0 +1,15 @@
+'use strict';
+
+// eslint-disable-next-line no-undef
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        if (process.env.NODE_ENV === 'test') {
+            return;
+        }
+
+        await queryInterface.sequelize.query('DROP TRIGGER IF EXISTS update_claim_states ON ubi_claim');
+        await queryInterface.sequelize.query('DROP TRIGGER IF EXISTS update_inflow_community_states ON inflow');
+    },
+
+    down(queryInterface, Sequelize) {},
+};

--- a/src/database/migrations/z1636472208-update-triggers.js
+++ b/src/database/migrations/z1636472208-update-triggers.js
@@ -7,8 +7,62 @@ module.exports = {
             return;
         }
 
-        await queryInterface.sequelize.query('DROP TRIGGER IF EXISTS update_claim_states ON ubi_claim');
-        await queryInterface.sequelize.query('DROP TRIGGER IF EXISTS update_inflow_community_states ON inflow');
+        await queryInterface.sequelize.query(`
+        CREATE OR REPLACE FUNCTION update_inflow_community_states()
+    RETURNS TRIGGER AS $$
+    declare
+        -- state_raised numeric(29);
+        -- state_daily_raised numeric(29);
+        n_backer bigint;
+        community_id integer;
+    BEGIN
+        SELECT id INTO community_id FROM community where "contractAddress"=NEW."contractAddress";
+        
+        IF community_id is null THEN
+			return new;
+		end if;
+
+        -- if this address never donated, it's a new backer
+        SELECT count(*) INTO n_backer FROM inflow WHERE "from" = NEW."from" AND "contractAddress"=NEW."contractAddress";
+        IF n_backer = 0 THEN
+            UPDATE ubi_community_state SET backers = backers + 1 WHERE "communityId"=community_id;
+        end if;
+        -- update total raised
+        -- SELECT SUM(raised + NEW.amount) INTO state_raised FROM ubi_community_state WHERE "communityId"=community_id;
+        -- UPDATE ubi_community_state SET raised = state_raised WHERE "communityId"=community_id;
+        -- SELECT SUM(raised + NEW.amount) INTO state_daily_raised FROM ubi_community_daily_state WHERE "communityId"=community_id AND date=DATE(NEW."txAt");
+        -- UPDATE ubi_community_daily_state SET raised = state_daily_raised WHERE "communityId"=community_id AND date=DATE(NEW."txAt");
+        return NEW;
+    END;
+$$ LANGUAGE plpgsql;`);
+
+        await queryInterface.sequelize.query(`
+        CREATE OR REPLACE FUNCTION update_claim_states()
+    RETURNS TRIGGER AS $$
+    declare
+        -- state_claimed numeric(29);
+        -- state_daily_claimed numeric(29);
+        beneficiary_claimed numeric(22);
+        beneficiary_last_claim_at timestamp with time zone;
+        community_public_id uuid;
+    BEGIN
+        SELECT "publicId" INTO community_public_id FROM community where id=NEW."communityId";
+        -- update claims
+        UPDATE ubi_community_state SET claims = claims + 1 WHERE "communityId"=NEW."communityId";
+        -- UPDATE ubi_community_daily_state SET claims = claims + 1 WHERE "communityId"=community_id AND date=DATE(NEW."txAt");
+        -- update beneficiary table as well
+        SELECT "lastClaimAt" INTO beneficiary_last_claim_at FROM beneficiary WHERE "communityId"=community_public_id AND address=NEW.address;
+        UPDATE beneficiary SET claims = claims + 1, "penultimateClaimAt"=beneficiary_last_claim_at, "lastClaimAt"=NEW."txAt" WHERE "communityId"=community_public_id AND address=NEW.address;
+        SELECT SUM(claimed + NEW.amount) INTO beneficiary_claimed FROM beneficiary WHERE "communityId"=community_public_id AND address=NEW.address;
+        UPDATE beneficiary SET claimed = beneficiary_claimed WHERE "communityId"=community_public_id AND address=NEW.address;
+        -- update total claimed
+        -- SELECT SUM(claimed + NEW.amount) INTO state_claimed FROM ubi_community_state WHERE "communityId"=NEW."communityId";
+        -- UPDATE ubi_community_state SET claimed = state_claimed WHERE "communityId"=NEW."communityId";
+        -- SELECT SUM(claimed + NEW.amount) INTO state_daily_claimed FROM ubi_community_daily_state WHERE "communityId"=community_id AND date=DATE(NEW."txAt");
+        -- UPDATE ubi_community_daily_state SET claimed = state_daily_claimed WHERE "communityId"=community_id AND date=DATE(NEW."txAt");
+        return NEW;
+    END;
+$$ LANGUAGE plpgsql;`);
     },
 
     down(queryInterface, Sequelize) {},

--- a/src/database/migrations/zz-create-triggers.js
+++ b/src/database/migrations/zz-create-triggers.js
@@ -38,7 +38,7 @@ EXECUTE PROCEDURE update_beneficiaries_community_states();`);
         CREATE OR REPLACE FUNCTION update_claim_states()
     RETURNS TRIGGER AS $$
     declare
-        state_claimed numeric(29);
+        -- state_claimed numeric(29);
         -- state_daily_claimed numeric(29);
         beneficiary_claimed numeric(22);
         beneficiary_last_claim_at timestamp with time zone;
@@ -54,8 +54,8 @@ EXECUTE PROCEDURE update_beneficiaries_community_states();`);
         SELECT SUM(claimed + NEW.amount) INTO beneficiary_claimed FROM beneficiary WHERE "communityId"=community_public_id AND address=NEW.address;
         UPDATE beneficiary SET claimed = beneficiary_claimed WHERE "communityId"=community_public_id AND address=NEW.address;
         -- update total claimed
-        SELECT SUM(claimed + NEW.amount) INTO state_claimed FROM ubi_community_state WHERE "communityId"=NEW."communityId";
-        UPDATE ubi_community_state SET claimed = state_claimed WHERE "communityId"=NEW."communityId";
+        -- SELECT SUM(claimed + NEW.amount) INTO state_claimed FROM ubi_community_state WHERE "communityId"=NEW."communityId";
+        -- UPDATE ubi_community_state SET claimed = state_claimed WHERE "communityId"=NEW."communityId";
         -- SELECT SUM(claimed + NEW.amount) INTO state_daily_claimed FROM ubi_community_daily_state WHERE "communityId"=community_id AND date=DATE(NEW."txAt");
         -- UPDATE ubi_community_daily_state SET claimed = state_daily_claimed WHERE "communityId"=community_id AND date=DATE(NEW."txAt");
         return NEW;
@@ -97,7 +97,7 @@ EXECUTE PROCEDURE update_managers_community_state();`);
         CREATE OR REPLACE FUNCTION update_inflow_community_states()
     RETURNS TRIGGER AS $$
     declare
-        state_raised numeric(29);
+        -- state_raised numeric(29);
         -- state_daily_raised numeric(29);
         n_backer bigint;
         community_id integer;
@@ -114,8 +114,8 @@ EXECUTE PROCEDURE update_managers_community_state();`);
             UPDATE ubi_community_state SET backers = backers + 1 WHERE "communityId"=community_id;
         end if;
         -- update total raised
-        SELECT SUM(raised + NEW.amount) INTO state_raised FROM ubi_community_state WHERE "communityId"=community_id;
-        UPDATE ubi_community_state SET raised = state_raised WHERE "communityId"=community_id;
+        -- SELECT SUM(raised + NEW.amount) INTO state_raised FROM ubi_community_state WHERE "communityId"=community_id;
+        -- UPDATE ubi_community_state SET raised = state_raised WHERE "communityId"=community_id;
         -- SELECT SUM(raised + NEW.amount) INTO state_daily_raised FROM ubi_community_daily_state WHERE "communityId"=community_id AND date=DATE(NEW."txAt");
         -- UPDATE ubi_community_daily_state SET raised = state_daily_raised WHERE "communityId"=community_id AND date=DATE(NEW."txAt");
         return NEW;

--- a/src/services/ubi/claim.ts
+++ b/src/services/ubi/claim.ts
@@ -1,6 +1,6 @@
 import { UbiClaimCreation } from '@interfaces/ubi/ubiClaim';
 import { Logger } from '@utils/logger';
-import { col, fn, Op } from 'sequelize';
+import { col, fn, literal, Op } from 'sequelize';
 
 import { models } from '../../database';
 
@@ -8,6 +8,17 @@ export default class ClaimService {
     public static async add(claimData: UbiClaimCreation): Promise<void> {
         try {
             await models.ubiClaim.create(claimData);
+            const claimed: any = literal(`"claimed" + ${claimData.amount}`);
+            await models.ubiCommunityState.update(
+                {
+                    claimed,
+                },
+                {
+                    where: {
+                        communityId: claimData.communityId,
+                    },
+                }
+            );
         } catch (e) {
             if (e.name !== 'SequelizeUniqueConstraintError') {
                 Logger.error(

--- a/tests/factories/claim.ts
+++ b/tests/factories/claim.ts
@@ -1,7 +1,7 @@
 import { BeneficiaryAttributes } from '../../src/database/models/ubi/beneficiary';
 import { CommunityAttributes } from '../../src/database/models/ubi/community';
-import { UbiClaimModel } from '../../src/database/models/ubi/ubiClaim';
 import { UbiClaimCreation } from '../../src/interfaces/ubi/ubiClaim';
+import ClaimService from '../../src/services/ubi/claim';
 import { randomTx } from '../utils/utils';
 /**
  * Generate an object which container attributes needed
@@ -35,6 +35,6 @@ const ClaimFactory = async (
     beneficiary: BeneficiaryAttributes,
     community: CommunityAttributes
 ) => {
-    return await UbiClaimModel.create(await data(beneficiary, community));
+    return ClaimService.add(await data(beneficiary, community));
 };
 export default ClaimFactory;

--- a/tests/factories/inflow.ts
+++ b/tests/factories/inflow.ts
@@ -2,10 +2,8 @@ import BigNumber from 'bignumber.js';
 import { ethers } from 'ethers';
 
 import { CommunityAttributes } from '../../src/database/models/ubi/community';
-import {
-    Inflow,
-    InflowCreationAttributes,
-} from '../../src/database/models/ubi/inflow';
+import { InflowCreationAttributes } from '../../src/database/models/ubi/inflow';
+import InflowService from '../../src/services/ubi/inflow';
 import { randomTx } from '../utils/utils';
 /**
  * Generate an object which container attributes needed
@@ -18,8 +16,8 @@ import { randomTx } from '../utils/utils';
 const data = async (community: CommunityAttributes) => {
     const randomWallet = ethers.Wallet.createRandom();
     const amount = new BigNumber(community.contract!.claimAmount)
-    .multipliedBy(5)
-    .toString();
+        .multipliedBy(5)
+        .toString();
     const defaultProps: InflowCreationAttributes = {
         from: await randomWallet.getAddress(),
         amount,
@@ -38,6 +36,13 @@ const data = async (community: CommunityAttributes) => {
  * @return {Object}       A user instance
  */
 const InflowFactory = async (community: CommunityAttributes) => {
-    return Inflow.create(await data(community));
+    const dataResult = await data(community);
+    return InflowService.add(
+        dataResult.from,
+        dataResult.contractAddress,
+        dataResult.amount,
+        dataResult.tx,
+        dataResult.txAt
+    );
 };
 export default InflowFactory;


### PR DESCRIPTION
This PR fixes [IPCT1-486] at https://impactmarket.atlassian.net/browse/IPCT1-486

## Changes
updated ClaimService and InflowService to update `claimed` and `raised` fields in ubi_community_state.
removed triggers: update_claim_states and update_inflow_community_states

## New

<!---
Specify what's new. New endpoints, etc.
-->

## Tests
new tests added