### PR TITLE
[IPCT1-477] - replace communityId community publicId in manager/beneficiary table to community id

### DIFF
--- a/src/api/controllers/community.ts
+++ b/src/api/controllers/community.ts
@@ -268,11 +268,8 @@ class CommunityController {
         ManagerService.get(req.user.address)
             .then(async (manager) => {
                 if (manager !== null) {
-                    const community = await CommunityService.getByPublicId(
-                        manager.communityId
-                    );
                     CommunityService.edit(
-                        community!.id,
+                        manager.id,
                         {
                             name,
                             description,

--- a/src/database/migrations/z1603462338-create-manager.js
+++ b/src/database/migrations/z1603462338-create-manager.js
@@ -12,12 +12,7 @@ module.exports = {
                 allowNull: false,
             },
             communityId: {
-                type: Sequelize.UUID,
-                references: {
-                    model: 'community',
-                    key: 'publicId',
-                },
-                onDelete: 'RESTRICT',
+                type: Sequelize.INTEGER,
                 allowNull: false,
             },
             active: {

--- a/src/database/migrations/z1603462338-create-manager.js
+++ b/src/database/migrations/z1603462338-create-manager.js
@@ -9,11 +9,6 @@ module.exports = {
             },
             address: {
                 type: Sequelize.STRING(44),
-                // references: {
-                //     model: 'user',
-                //     key: 'address',
-                // },
-                // onDelete: 'RESTRICT',
                 allowNull: false,
             },
             communityId: {

--- a/src/database/migrations/z1603464322-create-beneficiary.js
+++ b/src/database/migrations/z1603464322-create-beneficiary.js
@@ -9,20 +9,10 @@ module.exports = {
             },
             address: {
                 type: Sequelize.STRING(44),
-                // references: {
-                //     model: 'user',
-                //     key: 'address',
-                // },
-                // onDelete: 'RESTRICT', // delete only if active = false, separately
                 allowNull: false,
             },
             communityId: {
-                type: Sequelize.UUID,
-                references: {
-                    model: 'community',
-                    key: 'publicId',
-                },
-                onDelete: 'RESTRICT',
+                type: Sequelize.INTEGER,
                 allowNull: false,
             },
             active: {

--- a/src/database/migrations/z1638476957-update-manager.js
+++ b/src/database/migrations/z1638476957-update-manager.js
@@ -1,0 +1,21 @@
+'use strict';
+
+// eslint-disable-next-line no-undef
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        if (process.env.NODE_ENV === 'test') {
+            return;
+        }
+
+        await queryInterface.removeConstraint('manager', 'manager_communityId_fkey');
+        await queryInterface.renameColumn('manager', 'communityId', 'communityPublicId');
+
+        await queryInterface.addColumn('manager', 'communityId', {
+            type: Sequelize.INTEGER,
+            allowNull: false,
+            defaultValue: 1
+        });
+    },
+
+    down(queryInterface, Sequelize) {},
+};

--- a/src/database/migrations/z1638477479-populate-manager.js
+++ b/src/database/migrations/z1638477479-populate-manager.js
@@ -1,0 +1,25 @@
+'use strict';
+
+// eslint-disable-next-line no-undef
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        if (process.env.NODE_ENV === 'test') {
+            return;
+        }
+
+        const query = `
+            UPDATE manager
+            SET "communityId" = "community".id
+            FROM (SELECT id, "publicId" FROM community) "community"
+            WHERE "manager"."communityPublicId" = "community"."publicId"`;
+
+        await queryInterface.sequelize.query(query, {
+            raw: true,
+            type: Sequelize.QueryTypes.UPDATE,
+        });
+
+        await queryInterface.removeColumn('manager', 'communityPublicId');
+    },
+
+    down(queryInterface, Sequelize) {},
+};

--- a/src/database/migrations/z1638538441-update-beneficiary.js
+++ b/src/database/migrations/z1638538441-update-beneficiary.js
@@ -1,0 +1,21 @@
+'use strict';
+
+// eslint-disable-next-line no-undef
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        if (process.env.NODE_ENV === 'test') {
+            return;
+        }
+
+        await queryInterface.removeConstraint('beneficiary', 'beneficiary_communityId_fkey');
+        await queryInterface.renameColumn('beneficiary', 'communityId', 'communityPublicId');
+
+        await queryInterface.addColumn('beneficiary', 'communityId', {
+            type: Sequelize.INTEGER,
+            allowNull: false,
+            defaultValue: 1
+        });
+    },
+
+    down(queryInterface, Sequelize) {},
+};

--- a/src/database/migrations/z1638538455-populate-beneficiary.js
+++ b/src/database/migrations/z1638538455-populate-beneficiary.js
@@ -1,0 +1,25 @@
+'use strict';
+
+// eslint-disable-next-line no-undef
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        if (process.env.NODE_ENV === 'test') {
+            return;
+        }
+
+        const query = `
+            UPDATE beneficiary
+            SET "communityId" = "community".id
+            FROM (SELECT id, "publicId" FROM community) "community"
+            WHERE "beneficiary"."communityPublicId" = "community"."publicId"`;
+
+        await queryInterface.sequelize.query(query, {
+            raw: true,
+            type: Sequelize.QueryTypes.UPDATE,
+        });
+
+        await queryInterface.removeColumn('beneficiary', 'communityPublicId');
+    },
+
+    down(queryInterface, Sequelize) {},
+};

--- a/src/database/migrations/z1638546117-update-triggers copy.js
+++ b/src/database/migrations/z1638546117-update-triggers copy.js
@@ -1,0 +1,30 @@
+'use strict';
+
+// eslint-disable-next-line no-undef
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        if (process.env.NODE_ENV === 'test') {
+            return;
+        }
+
+        await queryInterface.sequelize.query(`
+        CREATE OR REPLACE FUNCTION update_claim_states()
+    RETURNS TRIGGER AS $$
+    declare
+        -- state_claimed numeric(29);
+        -- state_daily_claimed numeric(29);
+        beneficiary_claimed numeric(22);
+        beneficiary_last_claim_at timestamp with time zone;
+    BEGIN
+        -- update beneficiary table
+        SELECT "lastClaimAt" INTO beneficiary_last_claim_at FROM beneficiary WHERE "communityId"=NEW."communityId" AND address=NEW.address;
+        UPDATE beneficiary SET claims = claims + 1, "penultimateClaimAt"=beneficiary_last_claim_at, "lastClaimAt"=NEW."txAt" WHERE "communityId"=NEW."communityId" AND address=NEW.address;
+        SELECT SUM(claimed + NEW.amount) INTO beneficiary_claimed FROM beneficiary WHERE "communityId"=NEW."communityId" AND address=NEW.address;
+        UPDATE beneficiary SET claimed = beneficiary_claimed WHERE "communityId"=NEW."communityId" AND address=NEW.address;
+        return NEW;
+    END;
+$$ LANGUAGE plpgsql;`);
+    },
+
+    down(queryInterface, Sequelize) {},
+};

--- a/src/database/migrations/z1638546117-update-triggers copy.js
+++ b/src/database/migrations/z1638546117-update-triggers copy.js
@@ -11,8 +11,6 @@ module.exports = {
         CREATE OR REPLACE FUNCTION update_claim_states()
     RETURNS TRIGGER AS $$
     declare
-        -- state_claimed numeric(29);
-        -- state_daily_claimed numeric(29);
         beneficiary_claimed numeric(22);
         beneficiary_last_claim_at timestamp with time zone;
     BEGIN

--- a/src/database/migrations/z1638546117-update-triggers.js
+++ b/src/database/migrations/z1638546117-update-triggers.js
@@ -22,6 +22,8 @@ module.exports = {
         return NEW;
     END;
 $$ LANGUAGE plpgsql;`);
+    
+        await queryInterface.sequelize.query(`DROP TRIGGER IF EXISTS update_inflow_community_states ON inflow`);
     },
 
     down(queryInterface, Sequelize) {},

--- a/src/database/migrations/zz-create-triggers.js
+++ b/src/database/migrations/zz-create-triggers.js
@@ -26,32 +26,6 @@ ON ubi_claim
 FOR EACH ROW
 EXECUTE PROCEDURE update_claim_states();`);
 
-        await queryInterface.sequelize.query(`
-        CREATE OR REPLACE FUNCTION update_inflow_community_states()
-    RETURNS TRIGGER AS $$
-    declare
-        n_backer bigint;
-        community_id integer;
-    BEGIN
-        SELECT id INTO community_id FROM community where "contractAddress"=NEW."contractAddress";
-        
-        IF community_id is null THEN
-			return new;
-		end if;
-        -- if this address never donated, it's a new backer
-        SELECT count(*) INTO n_backer FROM inflow WHERE "from" = NEW."from" AND "contractAddress"=NEW."contractAddress";
-        IF n_backer = 0 THEN
-            UPDATE ubi_community_state SET backers = backers + 1 WHERE "communityId"=community_id;
-        end if;
-        return NEW;
-    END;
-$$ LANGUAGE plpgsql;
-CREATE TRIGGER update_inflow_community_states
-BEFORE INSERT
-ON inflow
-FOR EACH ROW
-EXECUTE PROCEDURE update_inflow_community_states();`);
-
         return queryInterface.sequelize.query(`
         CREATE OR REPLACE FUNCTION update_loves_stories()
     RETURNS TRIGGER AS $$

--- a/src/database/migrations/zz-create-triggers.js
+++ b/src/database/migrations/zz-create-triggers.js
@@ -11,14 +11,12 @@ module.exports = {
     declare
         beneficiary_claimed numeric(22);
         beneficiary_last_claim_at timestamp with time zone;
-        community_public_id uuid;
     BEGIN
-        SELECT "publicId" INTO community_public_id FROM community where id=NEW."communityId";
-        -- update beneficiary table as well
-        SELECT "lastClaimAt" INTO beneficiary_last_claim_at FROM beneficiary WHERE "communityId"=community_public_id AND address=NEW.address;
-        UPDATE beneficiary SET claims = claims + 1, "penultimateClaimAt"=beneficiary_last_claim_at, "lastClaimAt"=NEW."txAt" WHERE "communityId"=community_public_id AND address=NEW.address;
-        SELECT SUM(claimed + NEW.amount) INTO beneficiary_claimed FROM beneficiary WHERE "communityId"=community_public_id AND address=NEW.address;
-        UPDATE beneficiary SET claimed = beneficiary_claimed WHERE "communityId"=community_public_id AND address=NEW.address;
+        -- update beneficiary table
+        SELECT "lastClaimAt" INTO beneficiary_last_claim_at FROM beneficiary WHERE "communityId"=NEW."communityId" AND address=NEW.address;
+        UPDATE beneficiary SET claims = claims + 1, "penultimateClaimAt"=beneficiary_last_claim_at, "lastClaimAt"=NEW."txAt" WHERE "communityId"=NEW."communityId" AND address=NEW.address;
+        SELECT SUM(claimed + NEW.amount) INTO beneficiary_claimed FROM beneficiary WHERE "communityId"=NEW."communityId" AND address=NEW.address;
+        UPDATE beneficiary SET claimed = beneficiary_claimed WHERE "communityId"=NEW."communityId" AND address=NEW.address;
         return NEW;
     END;
 $$ LANGUAGE plpgsql;

--- a/src/database/models/associations/community.ts
+++ b/src/database/models/associations/community.ts
@@ -53,14 +53,14 @@ export function communityAssociation(sequelize: Sequelize) {
     // used to query from the community with incude
     sequelize.models.Community.hasMany(sequelize.models.Beneficiary, {
         foreignKey: 'communityId',
-        sourceKey: 'publicId',
+        sourceKey: 'id',
         as: 'beneficiaries',
     });
 
     // used to query from the community with incude
     sequelize.models.Community.hasMany(sequelize.models.Manager, {
         foreignKey: 'communityId',
-        sourceKey: 'publicId',
+        sourceKey: 'id',
         as: 'managers',
     });
 

--- a/src/database/models/associations/user.ts
+++ b/src/database/models/associations/user.ts
@@ -98,14 +98,14 @@ export function userAssociation(sequelize: Sequelize) {
     // beneficiaries are linked to manager through communityId
     sequelize.models.Beneficiary.belongsTo(sequelize.models.Community, {
         foreignKey: 'communityId',
-        targetKey: 'publicId',
+        targetKey: 'id',
         as: 'community',
     });
 
     // beneficiaries are linked to manager through communityId
     sequelize.models.Manager.belongsTo(sequelize.models.Community, {
         foreignKey: 'communityId',
-        targetKey: 'publicId',
+        targetKey: 'id',
         as: 'community',
     });
 

--- a/src/database/models/ubi/beneficiary.ts
+++ b/src/database/models/ubi/beneficiary.ts
@@ -6,7 +6,7 @@ import { CommunityAttributes } from './community';
 export interface BeneficiaryAttributes {
     id: number;
     address: string;
-    communityId: string;
+    communityId: number;
     active: boolean;
     blocked: boolean;
     tx: string;
@@ -26,7 +26,7 @@ export interface BeneficiaryAttributes {
 }
 export interface BeneficiaryCreationAttributes {
     address: string;
-    communityId: string;
+    communityId: number;
     tx: string;
     txAt: Date;
 }
@@ -37,7 +37,7 @@ export class Beneficiary extends Model<
 > {
     public id!: number;
     public address!: string;
-    public communityId!: string;
+    public communityId!: number;
     public active!: boolean;
     public blocked!: boolean;
     public tx!: string;
@@ -67,12 +67,7 @@ export function initializeBeneficiary(sequelize: Sequelize): void {
                 allowNull: false,
             },
             communityId: {
-                type: DataTypes.UUID,
-                references: {
-                    model: 'community',
-                    key: 'publicId',
-                },
-                onDelete: 'RESTRICT',
+                type: DataTypes.INTEGER,
                 allowNull: false,
             },
             active: {

--- a/src/database/models/ubi/manager.ts
+++ b/src/database/models/ubi/manager.ts
@@ -7,7 +7,7 @@ import { CommunityAttributes } from './community';
 export interface ManagerAttributes {
     id: number;
     address: string;
-    communityId: string;
+    communityId: number;
     active: boolean;
     readRules: boolean;
     blocked: boolean;
@@ -22,7 +22,7 @@ export interface ManagerAttributes {
 }
 export interface ManagerCreationAttributes {
     address: string;
-    communityId: string;
+    communityId: number;
 }
 export class Manager extends Model<
     ManagerAttributes,
@@ -30,7 +30,7 @@ export class Manager extends Model<
 > {
     public id!: number;
     public address!: string;
-    public communityId!: string;
+    public communityId!: number;
     public active!: boolean;
     public readRules!: boolean;
     public blocked!: boolean;
@@ -58,12 +58,7 @@ export function initializeManager(sequelize: Sequelize): void {
                 allowNull: false,
             },
             communityId: {
-                type: DataTypes.UUID,
-                references: {
-                    model: 'community',
-                    key: 'publicId',
-                },
-                onDelete: 'RESTRICT',
+                type: DataTypes.INTEGER,
                 allowNull: false,
             },
             active: {

--- a/src/services/app/user.ts
+++ b/src/services/app/user.ts
@@ -506,15 +506,7 @@ export default class UserService {
         let community: CommunityAttributes | null = null;
         let managerInPendingCommunity = false;
         // reusable method
-        const getCommunity = async (publicId: string) => {
-            const community = await CommunityService.getCommunityOnlyByPublicId(
-                publicId
-            );
-            if (community !== null) {
-                return CommunityService.findById(community.id);
-            }
-            return null;
-        };
+        const getCommunity = async (communityId: number) => CommunityService.findById(communityId);
 
         if (beneficiary) {
             community = await getCommunity(beneficiary.communityId);

--- a/src/services/ubi/beneficiary.ts
+++ b/src/services/ubi/beneficiary.ts
@@ -30,7 +30,7 @@ export default class BeneficiaryService {
     public static async add(
         address: string,
         from: string,
-        communityId: string,
+        communityId: number,
         tx: string,
         txAt: Date
     ): Promise<boolean> {
@@ -41,15 +41,11 @@ export default class BeneficiaryService {
             txAt,
         };
         try {
-            const community = await models.community.findOne({
-                attributes: ['id'],
-                where: { publicId: communityId },
-            });
             await models.beneficiary.create(beneficiaryData);
             await this._addRegistry({
                 address,
                 from,
-                communityId: community!.id,
+                communityId,
                 activity: UbiBeneficiaryRegistryType.add,
                 tx,
                 txAt,
@@ -61,7 +57,7 @@ export default class BeneficiaryService {
                 },
                 {
                     where: {
-                        communityId: community!.id,
+                        communityId,
                     },
                 }
             );
@@ -80,14 +76,10 @@ export default class BeneficiaryService {
     public static async remove(
         address: string,
         from: string,
-        communityId: string,
+        communityId: number,
         tx: string,
         txAt: Date
     ): Promise<void> {
-        const community = await models.community.findOne({
-            attributes: ['id'],
-            where: { publicId: communityId },
-        });
         await models.beneficiary.update(
             { active: false },
             { where: { address, communityId } }
@@ -95,7 +87,7 @@ export default class BeneficiaryService {
         await this._addRegistry({
             address,
             from,
-            communityId: community!.id,
+            communityId,
             activity: UbiBeneficiaryRegistryType.remove,
             tx,
             txAt,
@@ -107,7 +99,7 @@ export default class BeneficiaryService {
             },
             {
                 where: {
-                    communityId: community!.id,
+                    communityId,
                 },
             }
         );
@@ -297,7 +289,7 @@ export default class BeneficiaryService {
 
     public static async getBeneficiaryFilter(
         filter: BeneficiaryFilterType,
-        communityId: string
+        communityId: number
     ) {
         let where = {};
 
@@ -340,7 +332,7 @@ export default class BeneficiaryService {
                     },
                 ],
                 where: {
-                    publicId: communityId,
+                    id: communityId,
                 },
             });
 

--- a/src/services/ubi/claim.ts
+++ b/src/services/ubi/claim.ts
@@ -1,8 +1,8 @@
 import { UbiClaimCreation } from '@interfaces/ubi/ubiClaim';
 import { Logger } from '@utils/logger';
-import { col, fn, Op } from 'sequelize';
+import { col, fn, Op, QueryTypes } from 'sequelize';
 
-import { models } from '../../database';
+import { models, sequelize } from '../../database';
 
 export default class ClaimService {
     public static async add(claimData: UbiClaimCreation): Promise<void> {

--- a/src/services/ubi/claim.ts
+++ b/src/services/ubi/claim.ts
@@ -1,8 +1,8 @@
 import { UbiClaimCreation } from '@interfaces/ubi/ubiClaim';
 import { Logger } from '@utils/logger';
-import { col, fn, Op, QueryTypes } from 'sequelize';
+import { col, fn, Op } from 'sequelize';
 
-import { models, sequelize } from '../../database';
+import { models } from '../../database';
 
 export default class ClaimService {
     public static async add(claimData: UbiClaimCreation): Promise<void> {

--- a/src/services/ubi/community.ts
+++ b/src/services/ubi/community.ts
@@ -1022,7 +1022,7 @@ export default class CommunityService {
         const communityBeneficiaryActivity = (await this.beneficiary.findAll({
             attributes: [[fn('COUNT', col('address')), 'count'], 'active'],
             where: {
-                communityId: community?.publicId,
+                communityId,
             },
             group: ['active'],
             raw: true,
@@ -1030,7 +1030,7 @@ export default class CommunityService {
 
         const communityManagerActivity = await this.manager.count({
             where: {
-                communityId: community?.publicId,
+                communityId,
                 active: true,
             },
         });

--- a/src/services/ubi/community.ts
+++ b/src/services/ubi/community.ts
@@ -154,7 +154,7 @@ export default class CommunityService {
             );
             // await CommunityStateService.add
             if (txReceipt !== undefined) {
-                await ManagerService.add(managerAddress, community.publicId, t);
+                await ManagerService.add(managerAddress, community.id, t);
             }
             // If the execution reaches this line, no errors were thrown.
             // We commit the transaction.
@@ -888,7 +888,7 @@ export default class CommunityService {
                 },
             ],
             where: {
-                communityId: community.publicId,
+                communityId: community.id,
                 ...activeCondition,
             },
         });
@@ -1130,9 +1130,9 @@ export default class CommunityService {
 
     public static async findByFirstManager(
         requestByAddress: string
-    ): Promise<string | null> {
+    ): Promise<number | null> {
         const community = await this.community.findOne({
-            attributes: ['publicId'],
+            attributes: ['id'],
             where: {
                 requestByAddress,
                 status: {
@@ -1142,7 +1142,7 @@ export default class CommunityService {
             raw: true,
         });
         if (community) {
-            return community.publicId;
+            return community.id;
         }
         return null;
     }
@@ -1842,7 +1842,7 @@ export default class CommunityService {
                 where: { address: userAddress, active: true },
             });
             if (manager !== null) {
-                showEmail = manager.communityId === community.publicId;
+                showEmail = manager.communityId === community.id;
             } else {
                 showEmail =
                     community.status === 'pending' &&

--- a/src/services/ubi/managers.ts
+++ b/src/services/ubi/managers.ts
@@ -13,7 +13,7 @@ export default class ManagerService {
 
     public static async add(
         address: string,
-        communityId: string,
+        communityId: number,
         t: Transaction | undefined = undefined
     ): Promise<boolean> {
         // if user does not exist, add to pending list
@@ -126,7 +126,7 @@ export default class ManagerService {
 
     public static async remove(
         address: string,
-        communityId: string
+        communityId: number
     ): Promise<void> {
         await this.manager.update(
             { active: false },

--- a/src/types/endpoints.ts
+++ b/src/types/endpoints.ts
@@ -82,12 +82,12 @@ export interface IManagersDetails {
 }
 
 export interface IManager {
-    communityId: string;
+    communityId: number;
     readRules: boolean;
 }
 
 export interface IBeneficiary {
-    communityId: string;
+    communityId: number;
     blocked: boolean;
     readRules: boolean;
 }

--- a/src/worker/jobs/cron/community.ts
+++ b/src/worker/jobs/cron/community.ts
@@ -16,7 +16,7 @@ export async function verifyCommunitySuspectActivity(): Promise<void> {
             count(*) filter ( where suspect is true ) AS "suspect",
             count(*) as "total"
         FROM "community" AS "Community"
-            INNER JOIN "beneficiary" AS "beneficiaries" ON "Community"."publicId" = "beneficiaries"."communityId" AND "beneficiaries"."active" = true
+            INNER JOIN "beneficiary" AS "beneficiaries" ON "Community"."id" = "beneficiaries"."communityId" AND "beneficiaries"."active" = true
             LEFT OUTER JOIN "app_user" AS "app_user" ON "beneficiaries"."address" = "app_user"."address"
         WHERE "Community"."status" = 'valid' AND "Community"."visibility" = 'public'
         GROUP BY "Community"."id"

--- a/src/worker/jobs/cron/global.ts
+++ b/src/worker/jobs/cron/global.ts
@@ -478,12 +478,6 @@ export async function calcuateGlobalMetrics(): Promise<void> {
         raw: true,
     });
     if (last.length === 0) {
-        const communitiesPublicId = (
-            await models.community.findAll({
-                attributes: ['publicId'],
-                where: { status: 'valid', visibility: 'public' },
-            })
-        ).map((c) => c.publicId);
         const communitiesId = (
             await models.community.findAll({
                 attributes: ['id'],
@@ -494,7 +488,7 @@ export async function calcuateGlobalMetrics(): Promise<void> {
         const totalBeneficiaries = await models.beneficiary.count({
             where: {
                 txAt: { [Op.lt]: yesterdayDateOnly },
-                communityId: { [Op.in]: communitiesPublicId },
+                communityId: { [Op.in]: communitiesId },
                 active: true,
             },
         });

--- a/tests/factories/beneficiary.ts
+++ b/tests/factories/beneficiary.ts
@@ -14,7 +14,7 @@ import { randomTx } from '../utils/utils';
  *
  * @return {Object}       An object to build the user from.
  */
-const data = async (user: AppUser, communityId: string) => {
+const data = async (user: AppUser, communityId: number) => {
     const defaultProps: BeneficiaryCreationAttributes = {
         address: user.address,
         communityId,
@@ -32,7 +32,7 @@ const data = async (user: AppUser, communityId: string) => {
  */
 const BeneficiaryFactory = async (
     user: AppUser[],
-    communityId: string,
+    communityId: number,
     isRemoving: boolean = false
 ) => {
     const result: BeneficiaryAttributes[] = [];

--- a/tests/factories/manager.ts
+++ b/tests/factories/manager.ts
@@ -13,7 +13,7 @@ import { AppUser } from '../../src/interfaces/app/appUser';
  *
  * @return {Object}       An object to build the user from.
  */
-const data = async (user: AppUser, communityId: string) => {
+const data = async (user: AppUser, communityId: number) => {
     const defaultProps: ManagerCreationAttributes = {
         address: user.address,
         communityId,
@@ -27,7 +27,7 @@ const data = async (user: AppUser, communityId: string) => {
  *
  * @return {Object}       A user instance
  */
-const ManagerFactory = async (user: AppUser[], communityId: string) => {
+const ManagerFactory = async (user: AppUser[], communityId: number) => {
     const result: ManagerAttributes[] = [];
     for (let index = 0; index < user.length; index++) {
         const newBneficiary: any = await Manager.create(

--- a/tests/integration/jobs/cron/calcuateCommunitiesMetrics.test.ts
+++ b/tests/integration/jobs/cron/calcuateCommunitiesMetrics.test.ts
@@ -97,7 +97,7 @@ describe('calcuateCommunitiesMetrics', () => {
         it('txs and inflow, few claims', async () => {
             await InflowFactory(community);
             await InflowFactory(community);
-            beneficiaries = await BeneficiaryFactory(users, community.publicId);
+            beneficiaries = await BeneficiaryFactory(users, community.id);
             await ClaimFactory(beneficiaries[0], community);
             await ClaimFactory(beneficiaries[1], community);
 
@@ -152,7 +152,7 @@ describe('calcuateCommunitiesMetrics', () => {
         it('txs and inflow, stops activity for four days', async () => {
             await InflowFactory(community);
             await InflowFactory(community);
-            beneficiaries = await BeneficiaryFactory(users, community.publicId);
+            beneficiaries = await BeneficiaryFactory(users, community.id);
             await ClaimFactory(beneficiaries[0], community);
             await ClaimFactory(beneficiaries[1], community);
 
@@ -221,7 +221,7 @@ describe('calcuateCommunitiesMetrics', () => {
         it('txs and inflow, stops activity for two days and gets activity again', async () => {
             await InflowFactory(community);
             await InflowFactory(community);
-            beneficiaries = await BeneficiaryFactory(users, community.publicId);
+            beneficiaries = await BeneficiaryFactory(users, community.id);
             await ClaimFactory(beneficiaries[0], community);
             await ClaimFactory(beneficiaries[1], community);
 
@@ -307,7 +307,7 @@ describe('calcuateCommunitiesMetrics', () => {
             await InflowFactory(community);
             const beneficiaries = await BeneficiaryFactory(
                 users,
-                community.publicId
+                community.id
             );
             await ClaimFactory(beneficiaries[0], community);
             await ClaimFactory(beneficiaries[1], community);
@@ -354,7 +354,7 @@ describe('calcuateCommunitiesMetrics', () => {
         it('inflow beneficiaries, no claims', async () => {
             await InflowFactory(community);
             await InflowFactory(community);
-            await BeneficiaryFactory(users, community.publicId);
+            await BeneficiaryFactory(users, community.id);
 
             // THIS IS HAPPENING TOMORROW
             tk.travel(jumpToTomorrowMidnight());
@@ -384,7 +384,7 @@ describe('calcuateCommunitiesMetrics', () => {
 
         it('no claims', async () => {
             await InflowFactory(community);
-            await BeneficiaryFactory(users, community.publicId);
+            await BeneficiaryFactory(users, community.id);
 
             // THIS IS HAPPENING TOMORROW
             tk.travel(jumpToTomorrowMidnight());
@@ -417,7 +417,7 @@ describe('calcuateCommunitiesMetrics', () => {
             await InflowFactory(community);
             const beneficiaries = await BeneficiaryFactory(
                 users,
-                community.publicId
+                community.id
             );
             await ClaimFactory(beneficiaries[0], community);
             await ClaimFactory(beneficiaries[1], community);
@@ -454,7 +454,7 @@ describe('calcuateCommunitiesMetrics', () => {
             await InflowFactory(community);
             const beneficiaries = await BeneficiaryFactory(
                 users,
-                community.publicId
+                community.id
             );
             await ClaimFactory(beneficiaries[0], community);
 
@@ -549,7 +549,7 @@ describe('calcuateCommunitiesMetrics', () => {
             await InflowFactory(community);
             let beneficiaries = await BeneficiaryFactory(
                 users.slice(0, 4),
-                community.publicId
+                community.id
             );
             await ClaimFactory(beneficiaries[0], community);
             await ClaimFactory(beneficiaries[1], community);
@@ -558,7 +558,7 @@ describe('calcuateCommunitiesMetrics', () => {
             // THIS IS HAPPENING TOMORROW
             tk.travel(jumpToTomorrowMidnight());
             beneficiaries = beneficiaries.concat(
-                await BeneficiaryFactory([users[4]], community.publicId)
+                await BeneficiaryFactory([users[4]], community.id)
             );
             await ClaimFactory(beneficiaries[0], community);
             tk.travel(new Date().getTime() + 1000 * 60 * 3);
@@ -573,11 +573,11 @@ describe('calcuateCommunitiesMetrics', () => {
             tk.travel(jumpToTomorrowMidnight());
             await BeneficiaryFactory(
                 users.slice(1, 4),
-                community.publicId,
+                community.id,
                 true
             );
             beneficiaries = beneficiaries.concat(
-                await BeneficiaryFactory([users[5]], community.publicId)
+                await BeneficiaryFactory([users[5]], community.id)
             );
             await ClaimFactory(beneficiaries[0], community);
             tk.travel(new Date().getTime() + 1000 * 60 * 8);

--- a/tests/integration/jobs/cron/calcuateGlobalMetrics.test.ts
+++ b/tests/integration/jobs/cron/calcuateGlobalMetrics.test.ts
@@ -76,7 +76,7 @@ describe('#calcuateGlobalMetrics()', () => {
         await InflowFactory(community);
         const beneficiaries = await BeneficiaryFactory(
             users,
-            community.publicId
+            community.id
         );
         await ClaimFactory(beneficiaries[0], community);
         await ClaimFactory(beneficiaries[1], community);
@@ -270,7 +270,7 @@ describe('#calcuateGlobalMetrics()', () => {
         await InflowFactory(community1);
         await InflowFactory(community1);
         beneficiaries = beneficiaries.concat(
-            await BeneficiaryFactory(users.slice(0, 2), community1.publicId)
+            await BeneficiaryFactory(users.slice(0, 2), community1.id)
         );
         await ClaimFactory(beneficiaries[0], community1);
         await ClaimFactory(beneficiaries[1], community1);
@@ -279,7 +279,7 @@ describe('#calcuateGlobalMetrics()', () => {
         await InflowFactory(community2);
         await InflowFactory(community2);
         beneficiaries = beneficiaries.concat(
-            await BeneficiaryFactory(users.slice(2, 5), community2.publicId)
+            await BeneficiaryFactory(users.slice(2, 5), community2.id)
         );
         await ClaimFactory(beneficiaries[2], community2);
         await ClaimFactory(beneficiaries[3], community2);
@@ -567,7 +567,7 @@ describe('#calcuateGlobalMetrics()', () => {
 
         // community 1
         beneficiaries = beneficiaries.concat(
-            await BeneficiaryFactory(users.slice(5, 7), community1.publicId)
+            await BeneficiaryFactory(users.slice(5, 7), community1.id)
         );
         await InflowFactory(community1);
         await ClaimFactory(beneficiaries[0], community1);
@@ -635,7 +635,7 @@ describe('#calcuateGlobalMetrics()', () => {
         await globalDailyStateCreate.resetHistory();
 
         // community 1
-        await BeneficiaryFactory(users.slice(5, 7), community1.publicId, true);
+        await BeneficiaryFactory(users.slice(5, 7), community1.id, true);
         await InflowFactory(community1);
         await ClaimFactory(beneficiaries[0], community1);
         tk.travel(new Date().getTime() + 1000 * 60 * 8);
@@ -649,7 +649,7 @@ describe('#calcuateGlobalMetrics()', () => {
         });
         // community 2
         beneficiaries = beneficiaries.concat(
-            await BeneficiaryFactory([users[7]], community2.publicId)
+            await BeneficiaryFactory([users[7]], community2.id)
         );
         await InflowFactory(community2);
         await ClaimFactory(beneficiaries[2], community2);
@@ -818,7 +818,7 @@ describe('#calcuateGlobalMetrics()', () => {
         await InflowFactory(community1);
         await InflowFactory(community1);
         beneficiaries = beneficiaries.concat(
-            await BeneficiaryFactory(users.slice(0, 2), community1.publicId)
+            await BeneficiaryFactory(users.slice(0, 2), community1.id)
         );
         await ClaimFactory(beneficiaries[0], community1);
         await ClaimFactory(beneficiaries[1], community1);
@@ -827,7 +827,7 @@ describe('#calcuateGlobalMetrics()', () => {
         await InflowFactory(community2);
         await InflowFactory(community2);
         beneficiaries = beneficiaries.concat(
-            await BeneficiaryFactory(users.slice(10, 13), community2.publicId)
+            await BeneficiaryFactory(users.slice(10, 13), community2.id)
         );
         await ClaimFactory(beneficiaries[2], community2);
         await ClaimFactory(beneficiaries[3], community2);
@@ -837,7 +837,7 @@ describe('#calcuateGlobalMetrics()', () => {
         await InflowFactory(community3);
         await InflowFactory(community3);
         beneficiaries = beneficiaries.concat(
-            await BeneficiaryFactory(users.slice(20, 24), community3.publicId)
+            await BeneficiaryFactory(users.slice(20, 24), community3.id)
         );
         await ClaimFactory(beneficiaries[5], community3);
         await ClaimFactory(beneficiaries[6], community3);
@@ -848,7 +848,7 @@ describe('#calcuateGlobalMetrics()', () => {
         await InflowFactory(community4);
         await InflowFactory(community4);
         beneficiaries = beneficiaries.concat(
-            await BeneficiaryFactory(users.slice(30, 34), community4.publicId)
+            await BeneficiaryFactory(users.slice(30, 34), community4.id)
         );
         await ClaimFactory(beneficiaries[9], community4);
         await ClaimFactory(beneficiaries[10], community4);
@@ -1119,7 +1119,7 @@ describe('#calcuateGlobalMetrics()', () => {
         });
         // community 3
         beneficiaries = beneficiaries.concat(
-            await BeneficiaryFactory(users.slice(24, 26), community3.publicId)
+            await BeneficiaryFactory(users.slice(24, 26), community3.id)
         );
         await InflowFactory(community3);
         await ClaimFactory(beneficiaries[5], community3);
@@ -1256,7 +1256,7 @@ describe('#calcuateGlobalMetrics()', () => {
 
         // community 1
         beneficiaries = beneficiaries.concat(
-            await BeneficiaryFactory(users.slice(5, 7), community1.publicId)
+            await BeneficiaryFactory(users.slice(5, 7), community1.id)
         );
         await InflowFactory(community1);
         await ClaimFactory(beneficiaries[0], community1);
@@ -1340,7 +1340,7 @@ describe('#calcuateGlobalMetrics()', () => {
         await globalDailyStateCreate.resetHistory();
 
         // community 1
-        await BeneficiaryFactory(users.slice(5, 7), community1.publicId, true);
+        await BeneficiaryFactory(users.slice(5, 7), community1.id, true);
         await InflowFactory(community1);
         await ClaimFactory(beneficiaries[0], community1);
         tk.travel(new Date().getTime() + 1000 * 60 * 8);
@@ -1354,7 +1354,7 @@ describe('#calcuateGlobalMetrics()', () => {
         });
         // community 2
         beneficiaries = beneficiaries.concat(
-            await BeneficiaryFactory([users[14]], community2.publicId)
+            await BeneficiaryFactory([users[14]], community2.id)
         );
         await InflowFactory(community2);
         await ClaimFactory(beneficiaries[2], community2);
@@ -1453,7 +1453,7 @@ describe('#calcuateGlobalMetrics()', () => {
         tk.travel(jumpToTomorrowMidnight());
         const beneficiaries = await BeneficiaryFactory(
             users,
-            community.publicId
+            community.id
         );
         await InflowFactory(community);
         await ClaimFactory(beneficiaries[0], community);
@@ -1496,7 +1496,7 @@ describe('#calcuateGlobalMetrics()', () => {
             },
             {
                 where: {
-                    communityId: community.publicId,
+                    communityId: community.id,
                 },
             }
         );

--- a/tests/integration/jobs/cron/verifyCommunitySuspectActivity.test.ts
+++ b/tests/integration/jobs/cron/verifyCommunitySuspectActivity.test.ts
@@ -10,7 +10,6 @@ import BeneficiaryFactory from '../../../factories/beneficiary';
 import CommunityFactory from '../../../factories/community';
 import UserFactory from '../../../factories/user';
 import truncate, { sequelizeSetup } from '../../../utils/sequelizeSetup';
-import tk from 'timekeeper';
 
 describe('[jobs - cron] verifyCommunitySuspectActivity', () => {
     let sequelize: Sequelize;
@@ -49,7 +48,7 @@ describe('[jobs - cron] verifyCommunitySuspectActivity', () => {
                 hasAddress: true,
             },
         ]);
-        await BeneficiaryFactory(users, communities[0].publicId);
+        await BeneficiaryFactory(users, communities[0].id);
 
         await verifyCommunitySuspectActivity();
         const suspectActivity = await models.ubiCommunitySuspect.findAll({
@@ -76,7 +75,7 @@ describe('[jobs - cron] verifyCommunitySuspectActivity', () => {
                 hasAddress: true,
             },
         ]);
-        await BeneficiaryFactory(users, communities[0].publicId);
+        await BeneficiaryFactory(users, communities[0].id);
 
         await verifyCommunitySuspectActivity();
         const suspectActivity = await models.ubiCommunitySuspect.findAll({
@@ -103,7 +102,7 @@ describe('[jobs - cron] verifyCommunitySuspectActivity', () => {
                 hasAddress: true,
             },
         ]);
-        await BeneficiaryFactory(users, communities[0].publicId);
+        await BeneficiaryFactory(users, communities[0].id);
 
         await verifyCommunitySuspectActivity();
         const suspectActivity = await models.ubiCommunitySuspect.findAll({
@@ -130,7 +129,7 @@ describe('[jobs - cron] verifyCommunitySuspectActivity', () => {
                 hasAddress: true,
             },
         ]);
-        await BeneficiaryFactory(users, communities[0].publicId);
+        await BeneficiaryFactory(users, communities[0].id);
 
         await verifyCommunitySuspectActivity();
         const suspectActivity = await models.ubiCommunitySuspect.findAll({
@@ -154,7 +153,7 @@ describe('[jobs - cron] verifyCommunitySuspectActivity', () => {
                 hasAddress: true,
             },
         ]);
-        await BeneficiaryFactory(users, communities[0].publicId);
+        await BeneficiaryFactory(users, communities[0].id);
 
         await verifyCommunitySuspectActivity();
         const suspectActivity = await models.ubiCommunitySuspect.findAll({

--- a/tests/integration/jobs/cron/verifyDeletedAccounts.test.ts
+++ b/tests/integration/jobs/cron/verifyDeletedAccounts.test.ts
@@ -75,7 +75,7 @@ describe('[jobs - cron] verifyDeletedAccounts', () => {
                 hasAddress: true,
             },
         ]);
-        managers = await ManagerFactory([users[0]], communities[0].publicId);
+        managers = await ManagerFactory([users[0]], communities[0].id);
 
         const randomWallet = ethers.Wallet.createRandom();
         const tx = randomTx();
@@ -85,7 +85,7 @@ describe('[jobs - cron] verifyDeletedAccounts', () => {
         await BeneficiaryService.add(
             users[1].address,
             users[0].address,
-            communities[0].publicId,
+            communities[0].id,
             tx,
             new Date()
         );
@@ -93,7 +93,7 @@ describe('[jobs - cron] verifyDeletedAccounts', () => {
         await BeneficiaryService.add(
             users[2].address,
             users[0].address,
-            communities[0].publicId,
+            communities[0].id,
             tx2,
             new Date()
         );
@@ -101,7 +101,7 @@ describe('[jobs - cron] verifyDeletedAccounts', () => {
         await BeneficiaryService.add(
             users[3].address,
             users[0].address,
-            communities[0].publicId,
+            communities[0].id,
             tx3,
             new Date()
         );

--- a/tests/integration/services/beneficiary.test.ts
+++ b/tests/integration/services/beneficiary.test.ts
@@ -260,8 +260,8 @@ describe('beneficiary service', () => {
             }
         );
         //
-        assert.callCount(spyBeneficiaryRegistryAdd, 1);
-        assert.calledWith(spyBeneficiaryRegistryAdd.getCall(0), {
+        assert.callCount(spyBeneficiaryRegistryAdd, 2);
+        assert.calledWith(spyBeneficiaryRegistryAdd.getCall(1), {
             address: users[15].address,
             from: users[0].address,
             communityId: communities[0].id,

--- a/tests/integration/services/beneficiary.test.ts
+++ b/tests/integration/services/beneficiary.test.ts
@@ -260,8 +260,8 @@ describe('beneficiary service', () => {
             }
         );
         //
-        assert.callCount(spyBeneficiaryRegistryAdd, 2);
-        assert.calledWith(spyBeneficiaryRegistryAdd.getCall(1), {
+        assert.callCount(spyBeneficiaryRegistryAdd, 1);
+        assert.calledWith(spyBeneficiaryRegistryAdd.getCall(0), {
             address: users[15].address,
             from: users[0].address,
             communityId: communities[0].id,

--- a/tests/integration/services/beneficiary.test.ts
+++ b/tests/integration/services/beneficiary.test.ts
@@ -76,10 +76,10 @@ describe('beneficiary service', () => {
                 hasAddress: true,
             },
         ]);
-        managers = await ManagerFactory([users[0]], communities[0].publicId);
+        managers = await ManagerFactory([users[0]], communities[0].id);
         beneficiaries = await BeneficiaryFactory(
             users.slice(0, 8),
-            communities[0].publicId
+            communities[0].id
         );
 
         spyBeneficiaryRegistryAdd = spy(
@@ -157,7 +157,7 @@ describe('beneficiary service', () => {
         beneficiaries = beneficiaries.concat(
             await BeneficiaryFactory(
                 users.slice(10, 15),
-                communities[0].publicId
+                communities[0].id
             )
         );
         // test results
@@ -199,7 +199,7 @@ describe('beneficiary service', () => {
         await BeneficiaryService.add(
             users[15].address,
             users[0].address,
-            communities[0].publicId,
+            communities[0].id,
             tx,
             txAt
         );
@@ -208,7 +208,7 @@ describe('beneficiary service', () => {
         assert.callCount(spyBeneficiaryAdd, 1);
         assert.calledWith(spyBeneficiaryAdd.getCall(0), {
             address: users[15].address,
-            communityId: communities[0].publicId,
+            communityId: communities[0].id,
             tx,
             txAt,
         });
@@ -231,7 +231,7 @@ describe('beneficiary service', () => {
         await BeneficiaryService.add(
             users[15].address,
             users[0].address,
-            communities[0].publicId,
+            communities[0].id,
             randomTx(),
             new Date()
         );
@@ -240,7 +240,7 @@ describe('beneficiary service', () => {
         await BeneficiaryService.remove(
             users[15].address,
             users[0].address,
-            communities[0].publicId,
+            communities[0].id,
             tx,
             txAt
         );
@@ -255,7 +255,7 @@ describe('beneficiary service', () => {
             {
                 where: {
                     address: users[15].address,
-                    communityId: communities[0].publicId,
+                    communityId: communities[0].id,
                 },
             }
         );
@@ -296,11 +296,11 @@ describe('beneficiary service', () => {
             ]);
             listManagers = await ManagerFactory(
                 [listUsers[0]],
-                listCommunity[0].publicId
+                listCommunity[0].id
             );
             beneficiaries = await BeneficiaryFactory(
                 listUsers,
-                listCommunity[0].publicId
+                listCommunity[0].id
             );
         });
 
@@ -473,7 +473,7 @@ describe('beneficiary service', () => {
             await BeneficiaryService.add(
                 users[16].address,
                 users[0].address,
-                communities[0].publicId,
+                communities[0].id,
                 tx,
                 new Date()
             );
@@ -603,7 +603,7 @@ describe('beneficiary service', () => {
             await BeneficiaryService.add(
                 users[17].address,
                 users[0].address,
-                communities[0].publicId,
+                communities[0].id,
                 tx,
                 new Date()
             );
@@ -616,7 +616,7 @@ describe('beneficiary service', () => {
             expect(user.beneficiary).to.include({
                 readRules: false,
                 blocked: false,
-                communityId: communities[0].publicId,
+                communityId: communities[0].id,
             });
         });
 
@@ -631,7 +631,7 @@ describe('beneficiary service', () => {
             expect(user.beneficiary).to.include({
                 readRules: true,
                 blocked: false,
-                communityId: communities[0].publicId,
+                communityId: communities[0].id,
             });
         });
     });
@@ -675,7 +675,7 @@ describe('beneficiary service', () => {
             await BeneficiaryService.add(
                 users[18].address,
                 users[1].address,
-                communities[1].publicId,
+                communities[1].id,
                 randomTx(),
                 new Date()
             );
@@ -683,7 +683,7 @@ describe('beneficiary service', () => {
             await BeneficiaryService.add(
                 users[19].address,
                 users[1].address,
-                communities[1].publicId,
+                communities[1].id,
                 randomTx(),
                 new Date()
             );
@@ -710,7 +710,7 @@ describe('beneficiary service', () => {
             await BeneficiaryService.add(
                 users[20].address,
                 users[1].address,
-                communities[1].publicId,
+                communities[1].id,
                 randomTx(),
                 new Date()
             );
@@ -718,7 +718,7 @@ describe('beneficiary service', () => {
             await BeneficiaryService.add(
                 users[21].address,
                 users[1].address,
-                communities[1].publicId,
+                communities[1].id,
                 randomTx(),
                 new Date()
             );
@@ -726,7 +726,7 @@ describe('beneficiary service', () => {
             await BeneficiaryService.remove(
                 users[20].address,
                 users[1].address,
-                communities[1].publicId,
+                communities[1].id,
                 randomTx(),
                 new Date()
             );
@@ -746,7 +746,7 @@ describe('beneficiary service', () => {
             await BeneficiaryService.add(
                 users[22].address,
                 users[0].address,
-                communities[0].publicId,
+                communities[0].id,
                 randomTx(),
                 new Date()
             );
@@ -754,7 +754,7 @@ describe('beneficiary service', () => {
             await BeneficiaryService.add(
                 users[23].address,
                 users[0].address,
-                communities[0].publicId,
+                communities[0].id,
                 randomTx(),
                 new Date()
             );

--- a/tests/integration/services/beneficiaryTransaction.test.ts
+++ b/tests/integration/services/beneficiaryTransaction.test.ts
@@ -38,7 +38,7 @@ describe('beneficiary transactions', () => {
         ]);
         const beneficiaries = await BeneficiaryFactory(
             users.slice(0, 5),
-            communities[0].publicId
+            communities[0].id
         );
         // add fake transactions
         await BeneficiaryTransactionFactory(beneficiaries[0], true, {

--- a/tests/integration/services/claimLocation.test.ts
+++ b/tests/integration/services/claimLocation.test.ts
@@ -1,18 +1,13 @@
 import { expect } from 'chai';
-import { ethers } from 'ethers';
-import faker from 'faker';
 import { Sequelize } from 'sequelize';
-import { assert, spy, replace, restore, SinonSpy } from 'sinon';
+import { assert, spy, SinonSpy } from 'sinon';
 
 import { models } from '../../../src/database';
 import { CommunityAttributes } from '../../../src/database/models/ubi/community';
-import { ManagerAttributes } from '../../../src/database/models/ubi/manager';
 import { AppUser } from '../../../src/interfaces/app/appUser';
-import UserService from '../../../src/services/app/user';
 import ClaimLocationService from '../../../src/services/ubi/claimLocation';
 import BeneficiaryFactory from '../../factories/beneficiary';
 import CommunityFactory from '../../factories/community';
-import ManagerFactory from '../../factories/manager';
 import UserFactory from '../../factories/user';
 import truncate, { sequelizeSetup } from '../../utils/sequelizeSetup';
 
@@ -57,8 +52,8 @@ describe('claim location service', () => {
                 hasAddress: true,
             },
         ]);
-        await BeneficiaryFactory(users.slice(0, 1), communities[0].publicId);
-        await BeneficiaryFactory(users.slice(1, 2), communities[1].publicId);
+        await BeneficiaryFactory(users.slice(0, 1), communities[0].id);
+        await BeneficiaryFactory(users.slice(1, 2), communities[1].id);
 
         spyClaimLocationAdd = spy(models.ubiClaimLocation, 'create');
     });

--- a/tests/integration/services/community.test.ts
+++ b/tests/integration/services/community.test.ts
@@ -489,7 +489,7 @@ describe('community service', () => {
                     await UserFactory({
                         n: Math.floor(Math.random() * 20),
                     }),
-                    community.publicId
+                    community.id
                 );
             }
 
@@ -539,7 +539,7 @@ describe('community service', () => {
                     await UserFactory({
                         n: Math.floor(Math.random() * 20),
                     }),
-                    community.publicId
+                    community.id
                 );
             }
 
@@ -612,7 +612,7 @@ describe('community service', () => {
                                     ? 3
                                     : 4,
                         }),
-                        community.publicId
+                        community.id
                     );
                 }
 
@@ -752,7 +752,7 @@ describe('community service', () => {
                                     ? 5
                                     : 4,
                         }),
-                        community.publicId
+                        community.id
                     );
                 }
 
@@ -848,7 +848,7 @@ describe('community service', () => {
                                     ? 3
                                     : 4,
                         }),
-                        community.publicId
+                        community.id
                     );
                 }
 
@@ -1449,7 +1449,7 @@ describe('community service', () => {
                 },
             ]);
 
-            await ManagerFactory([manager[0]], communities[0].publicId);
+            await ManagerFactory([manager[0]], communities[0].id);
 
             const communityNewDescription =
                 'bla bla bla, this community to the moon!';
@@ -1759,7 +1759,7 @@ describe('community service', () => {
                 },
             ]);
 
-            await ManagerFactory([manager[0]], communities[0].publicId);
+            await ManagerFactory([manager[0]], communities[0].id);
 
             const result = await CommunityService.findById(
                 communities[0].id,
@@ -1790,7 +1790,7 @@ describe('community service', () => {
                 },
             ]);
 
-            await ManagerFactory([manager[0]], communities[0].publicId);
+            await ManagerFactory([manager[0]], communities[0].id);
 
             const result = await CommunityService.findById(communities[0].id);
 
@@ -1818,7 +1818,7 @@ describe('community service', () => {
                 },
             ]);
 
-            await ManagerFactory([manager[0]], communities[0].publicId);
+            await ManagerFactory([manager[0]], communities[0].id);
 
             const result = await CommunityService.findByContractAddress(
                 communities[0].contractAddress!,
@@ -1849,7 +1849,7 @@ describe('community service', () => {
                 },
             ]);
 
-            await ManagerFactory([manager[0]], communities[0].publicId);
+            await ManagerFactory([manager[0]], communities[0].id);
 
             const result = await CommunityService.findByContractAddress(
                 communities[0].contractAddress!
@@ -1890,19 +1890,19 @@ describe('community service', () => {
             const tx = randomTx();
             const tx2 = randomTx();
 
-            await ManagerFactory(users.slice(0, 2), community[0].publicId),
+            await ManagerFactory(users.slice(0, 2), community[0].id),
                 await Promise.all([
                     BeneficiaryService.add(
                         users[2].address,
                         users[0].address,
-                        community[0].publicId,
+                        community[0].id,
                         tx,
                         new Date()
                     ),
                     BeneficiaryService.add(
                         users[3].address,
                         users[0].address,
-                        community[0].publicId,
+                        community[0].id,
                         tx2,
                         new Date()
                     ),
@@ -1942,11 +1942,11 @@ describe('community service', () => {
 
             const tx = randomTx();
 
-            await ManagerFactory(users.slice(0, 3), community[0].publicId);
+            await ManagerFactory(users.slice(0, 3), community[0].id);
             await BeneficiaryService.add(
                 users[3].address,
                 users[0].address,
-                community[0].publicId,
+                community[0].id,
                 tx,
                 new Date()
             );
@@ -2002,18 +2002,18 @@ describe('community service', () => {
 
             const tx = randomTx();
 
-            await ManagerFactory(users.slice(0, 2), community[0].publicId);
+            await ManagerFactory(users.slice(0, 2), community[0].id);
             await BeneficiaryService.add(
                 users[2].address,
                 users[0].address,
-                community[0].publicId,
+                community[0].id,
                 tx,
                 new Date()
             );
 
             await ManagerService.remove(
                 users[0].address,
-                community[0].publicId
+                community[0].id
             );
 
             const managers = await CommunityService.getManagers(

--- a/tests/integration/services/manager.test.ts
+++ b/tests/integration/services/manager.test.ts
@@ -42,7 +42,7 @@ describe('manager service', () => {
 
         // const t = await sequelize.transaction();
         // await ManagerService.add(users[0].address, communities[0].publicId, t);
-        await ManagerFactory([users[0]], communities[0].publicId);
+        await ManagerFactory([users[0]], communities[0].id);
 
     });
 
@@ -58,7 +58,7 @@ describe('manager service', () => {
             expect(user.manager).to.be.not.null;
             expect(user.manager).to.include({
                 readRules: false,
-                communityId: communities[0].publicId,
+                communityId: communities[0].id,
             });
         });
 
@@ -72,7 +72,7 @@ describe('manager service', () => {
             expect(user.manager).to.be.not.null;
             expect(user.manager).to.include({
                 readRules: true,
-                communityId: communities[0].publicId,
+                communityId: communities[0].id,
             });
         });
     });

--- a/tests/integration/services/reachedAddress.test.ts
+++ b/tests/integration/services/reachedAddress.test.ts
@@ -48,7 +48,7 @@ describe('reachedAddress', () => {
             },
         ]);
 
-        await sequelize.models.Community.bulkCreate([
+        const community = await sequelize.models.Community.bulkCreate([
             {
                 publicId: '073ddf28-4a3d-4e05-8570-ff38b656b46f',
                 requestByAddress: '0x002D33893983E187814Be1bdBe9852299829C554',
@@ -96,7 +96,7 @@ describe('reachedAddress', () => {
         await sequelize.models.Beneficiary.bulkCreate([
             {
                 address: '0xd55Fae4769e3240FfFf4c17cd2CC03143e55E420',
-                communityId: '073ddf28-4a3d-4e05-8570-ff38b656b46f',
+                communityId: (community as any)[0].id,
                 txAt: new Date(),
                 claims: 0,
                 lastClaimAt: null,
@@ -109,7 +109,7 @@ describe('reachedAddress', () => {
             },
             {
                 address: '0x002D33893983E187814Be1bdBe9852299829C554',
-                communityId: '073ddf28-4a3d-4e05-8570-ff38b656b46f',
+                communityId: (community as any)[0].id,
                 txAt: new Date(),
                 claims: 0,
                 lastClaimAt: null,

--- a/tests/integration/services/story.test.ts
+++ b/tests/integration/services/story.test.ts
@@ -86,7 +86,7 @@ describe('story service', () => {
                 maxClaim: '450000000000000000000',
             },
         };
-        await BeneficiaryFactory(users.slice(0, 3), community1.publicId);
+        await BeneficiaryFactory(users.slice(0, 3), community1.id);
         community2 = {
             ...communities[0],
             contract: {
@@ -97,7 +97,7 @@ describe('story service', () => {
                 maxClaim: '450000000000000000000',
             },
         };
-        await BeneficiaryFactory(users.slice(3, 6), community2.publicId);
+        await BeneficiaryFactory(users.slice(3, 6), community2.id);
     });
 
     after(async () => {

--- a/tests/integration/services/user.test.ts
+++ b/tests/integration/services/user.test.ts
@@ -695,7 +695,7 @@ describe('user service', () => {
             ]);
             managers = await ManagerFactory(
                 [users[0]],
-                communities[0].publicId
+                communities[0].id
             );
         });
 
@@ -708,7 +708,7 @@ describe('user service', () => {
         });
 
         it('manager should be able to be delete account', async () => {
-            await ManagerFactory([users[2], users[3]], communities[0].publicId);
+            await ManagerFactory([users[2], users[3]], communities[0].id);
 
             await UserService.delete(users[0].address);
 

--- a/tests/unit/jobs/communityContract.test.ts
+++ b/tests/unit/jobs/communityContract.test.ts
@@ -190,7 +190,7 @@ describe('communityContract', () => {
             beneficiaryAdd.getCall(0),
             accounts[2],
             accounts[1],
-            thisCommunityPublicId,
+            thisCommunityId,
             match.any,
             match.any
         );
@@ -204,7 +204,7 @@ describe('communityContract', () => {
             beneficiaryAdd.getCall(0),
             accounts[2],
             accounts[1],
-            thisCommunityPublicId2,
+            thisCommunityId2,
             match.any,
             match.any
         );
@@ -221,7 +221,7 @@ describe('communityContract', () => {
             beneficiaryRemoved.getCall(0),
             accounts[2],
             accounts[1],
-            thisCommunityPublicId,
+            thisCommunityId,
             match.any,
             match.any
         );
@@ -234,7 +234,7 @@ describe('communityContract', () => {
         assert.calledWith(
             managerAdd.getCall(0),
             accounts[3],
-            thisCommunityPublicId
+            thisCommunityId
         );
     });
 
@@ -245,7 +245,7 @@ describe('communityContract', () => {
         assert.calledWith(
             managerAdd.getCall(0),
             accounts[3],
-            thisCommunityPublicId2
+            thisCommunityId2
         );
     });
 
@@ -259,7 +259,7 @@ describe('communityContract', () => {
         assert.calledWith(
             managerRemove.getCall(0),
             accounts[3],
-            thisCommunityPublicId
+            thisCommunityId
         );
     });
 

--- a/tests/unit/jobs/subscribers.test.ts
+++ b/tests/unit/jobs/subscribers.test.ts
@@ -269,7 +269,7 @@ describe('[jobs] subscribers', () => {
         assert.calledWith(
             managerAdd.getCall(0),
             accounts[1],
-            thisCommunityPublicId
+            thisCommunityId
         );
     });
 
@@ -351,7 +351,7 @@ describe('[jobs] subscribers', () => {
             beneficiaryAdd.getCall(0),
             accounts[5],
             accounts[1],
-            thisCommunityPublicId,
+            thisCommunityId,
             match.any,
             match.any
         );
@@ -393,7 +393,7 @@ describe('[jobs] subscribers', () => {
             beneficiaryRemove.getCall(0),
             accounts[5],
             accounts[1],
-            thisCommunityPublicId,
+            thisCommunityId,
             match.any,
             match.any
         );
@@ -473,12 +473,12 @@ describe('[jobs] subscribers', () => {
         assert.calledWith(
             managerAdd.getCall(0),
             accounts[1],
-            thisCommunityPublicId
+            thisCommunityId
         );
         assert.calledWith(
             managerAdd.getCall(1),
             accounts[2],
-            thisCommunityPublicId
+            thisCommunityId
         );
     });
 
@@ -519,7 +519,7 @@ describe('[jobs] subscribers', () => {
         assert.calledWith(
             managerRemove.getCall(0),
             accounts[2],
-            thisCommunityPublicId
+            thisCommunityId
         );
     });
 


### PR DESCRIPTION
This PR fixes [IPCT1-477] at https://impactmarket.atlassian.net/browse/IPCT1-477

## Changes
replace `publicId` by community `id` in beneficiary and manager tables.

## New

<!---
Specify what's new. New endpoints, etc.
-->

## Tests
all tests runing