### PR TITLE
[IPCT1-543] - include survey id in registry

### DIFF
--- a/src/api/validators/user.ts
+++ b/src/api/validators/user.ts
@@ -116,6 +116,7 @@ const subscribeNewsletter = celebrate({
 const saveSurvey = celebrate({
     body: Joi.array().items(
         Joi.object({
+            surveyId: Joi.number().required(),
             answer: Joi.string().required(),
             question: Joi.number().required(),
         })

--- a/src/database/migrations/z1633992148-create-ubiBeneficiarySurvey.js
+++ b/src/database/migrations/z1633992148-create-ubiBeneficiarySurvey.js
@@ -13,6 +13,10 @@ module.exports = {
                 type: Sequelize.INTEGER,
                 allowNull: false,
             },
+            surveyId: {
+                type: Sequelize.INTEGER,
+                allowNull: false,
+            },
             question: {
                 type: Sequelize.INTEGER,
                 allowNull: false,

--- a/src/database/migrations/z1638901731-update-ubiBeneficiarySurvey.js
+++ b/src/database/migrations/z1638901731-update-ubiBeneficiarySurvey.js
@@ -1,0 +1,16 @@
+'use strict';
+
+// eslint-disable-next-line no-undef
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        if (process.env.NODE_ENV === 'test') {
+            return;
+        }
+        await queryInterface.addColumn('ubi_beneficiary_survey', 'surveyId', {
+            type: Sequelize.INTEGER,
+            allowNull: false,
+        });
+    },
+
+    down(queryInterface, Sequelize) {},
+};

--- a/src/database/models/ubi/ubiBeneficiarySurvey.ts
+++ b/src/database/models/ubi/ubiBeneficiarySurvey.ts
@@ -4,6 +4,7 @@ import { Sequelize, DataTypes, Model } from 'sequelize';
 export class UbiBeneficiarySurveyModel extends Model<UbiBeneficiarySurvey, UbiBeneficiarySurveyCreation> {
     public id!: number;
     public userId!: number;
+    public surveyId!: number;
     public question!: number;
     public answer!: string;
 
@@ -20,6 +21,10 @@ export function initializeUbiBeneficiarySurvey(sequelize: Sequelize): void {
                 primaryKey: true,
             },
             userId: {
+                type: DataTypes.INTEGER,
+                allowNull: false,
+            },
+            surveyId: {
                 type: DataTypes.INTEGER,
                 allowNull: false,
             },

--- a/src/interfaces/ubi/ubiBeneficiarySurvey.ts
+++ b/src/interfaces/ubi/ubiBeneficiarySurvey.ts
@@ -31,6 +31,7 @@
 export interface UbiBeneficiarySurvey {
     id: number;
     userId: number;
+    surveyId: number;
     question: number;
     answer: string;
 
@@ -40,6 +41,7 @@ export interface UbiBeneficiarySurvey {
 
 export interface UbiBeneficiarySurveyCreation {
     userId?: number;
+    surveyId: number;
     question: number;
     answer: string;
 }

--- a/tests/integration/services/beneficiary.test.ts
+++ b/tests/integration/services/beneficiary.test.ts
@@ -646,6 +646,7 @@ describe('beneficiary service', () => {
                     {
                         question: 1,
                         answer: 'answer',
+                        surveyId: 1,
                     },
                 ]
             );
@@ -653,6 +654,7 @@ describe('beneficiary service', () => {
             expect(result[0]).to.include({
                 question: 1,
                 answer: 'answer',
+                surveyId: 1,
             });
         });
 
@@ -661,6 +663,7 @@ describe('beneficiary service', () => {
                 {
                     question: 1,
                     answer: 'answer',
+                    surveyId: 1,
                 },
             ])
                 .catch((e) => expect(e.name).to.be.equal('USER_NOT_FOUND'))


### PR DESCRIPTION
This PR fixes [IPCT1-543] at https://impactmarket.atlassian.net/browse/IPCT1-543

## Changes
<!---
Describe the changes/feature. If there are many changes, create groups.
This change sometimes imply frontend changes, please be clear.
-->

## New
added `surveyId` in ubi_beneficiary_survey table

## Tests

<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->