### PR TITLE
[IPCT1-630] - get suspicious and inactive beneficiaries

### DIFF
--- a/packages/api/src/controllers/community.ts
+++ b/packages/api/src/controllers/community.ts
@@ -56,6 +56,22 @@ class CommunityController {
             .catch((e) => standardResponse(res, 400, false, '', { error: e }));
     };
 
+    getTotalBeneficiaries = (req: RequestWithUser, res: Response) => {
+        if (req.user === undefined) {
+            standardResponse(res, 400, false, '', {
+                error: {
+                    name: 'USER_NOT_FOUND',
+                    message: 'User not identified!',
+                },
+            });
+            return;
+        }
+
+        services.ubi.BeneficiaryService.getTotalBeneficiaries(req.user.address)
+            .then((r) => standardResponse(res, 200, true, r))
+            .catch((e) => standardResponse(res, 400, false, '', { error: e }));
+    };
+
     beneficiaries = (req: RequestWithUser, res: Response) => {
         if (req.user === undefined) {
             standardResponse(res, 400, false, '', {

--- a/packages/api/src/routes/community.ts
+++ b/packages/api/src/routes/community.ts
@@ -358,6 +358,38 @@ export default (app: Router): void => {
     /**
      * @swagger
      *
+     * /community/beneficiaries/total:
+     *   get:
+     *     tags:
+     *       - "community"
+     *     summary: Return the total of inactive and suspicious beneficiaries
+     *     responses:
+     *       "200":
+     *         description: OK
+     *         content:
+     *           application/json:
+     *             schema:
+     *               type: object
+     *               properties:
+     *                 suspicious:
+     *                   type: number
+     *                   description: Total of suspicious beneficiary.
+     *                 inactive:
+     *                   type: number
+     *                   description: Total of inactive beneficiary.
+     *     security:
+     *     - api_auth:
+     *       - "write:modify":
+     */
+    route.get(
+        '/beneficiaries/total',
+        authenticateToken,
+        controller.getTotalBeneficiaries
+    );
+
+    /**
+     * @swagger
+     *
      * /community/beneficiaries:
      *   get:
      *     tags:

--- a/packages/core/tests/integration/beneficiary.test.ts
+++ b/packages/core/tests/integration/beneficiary.test.ts
@@ -461,6 +461,37 @@ describe('beneficiary service', () => {
             );
             expect(result.length).to.be.equal(0);
         });
+
+        it('get total beneficiaries', async () => {
+            await models.beneficiary.update(
+                {
+                    active: false,
+                },
+                {
+                    where: {
+                        address: users[0].address,
+                    },
+                }
+            );
+
+            await models.appUser.update(
+                {
+                    suspect: true,
+                },
+                {
+                    where: {
+                        address: users[0].address,
+                    },
+                }
+            );
+
+            const total = await BeneficiaryService.getTotalBeneficiaries(
+                users[0].address
+            );
+
+            expect(total.inactive).to.be.equal(1);
+            expect(total.suspicious).to.be.equal(1);
+        });
     });
 
     describe('beneficiary activity', () => {


### PR DESCRIPTION
This PR fixes [IPCT1-630] at https://impactmarket.atlassian.net/browse/IPCT1-630

## Changes
<!---
Describe the changes/feature. If there are many changes, create groups.
This change sometimes imply frontend changes, please be clear.
-->

## New
New endpoint to return the number of suspicious and inactive beneficiaries

## Tests
new test added