### PR TITLE
[IPCT1-207] - Global demographics refactor

### DIFF
--- a/packages/api/src/controllers/global.ts
+++ b/packages/api/src/controllers/global.ts
@@ -6,6 +6,7 @@ import { standardResponse } from '../utils/api';
 const reachedAddressService = new services.ReachedAddressService();
 const globalGrowth = new services.global.GlobalGrowthService();
 const globalDailyStateService = new services.global.GlobalDailyStateService();
+const globalDemographicsService = new services.global.GlobalDemographicsService();
 
 const globalStatus = (req: Request, res: Response) => {
     const waitForResult = new Promise(async (resolve, reject) => {
@@ -30,7 +31,7 @@ const globalStatus = (req: Request, res: Response) => {
         .catch((e) => standardResponse(res, 400, false, '', { error: e }));
 };
 const globalDemographics = (req: Request, res: Response) => {
-    services.global.GlobalDemographicsService.getLast()
+    globalDemographicsService.get()
         .then((r) => res.send(r))
         .catch((e) => standardResponse(res, 400, false, '', { error: e }));
 };

--- a/packages/core/src/database/models/associations/community.ts
+++ b/packages/core/src/database/models/associations/community.ts
@@ -114,4 +114,8 @@ export function communityAssociation(sequelize: Sequelize) {
         sourceKey: 'ambassadorAddress',
         as: 'ambassador',
     });
+    sequelize.models.UbiCommunityDemographicsModel.belongsTo(sequelize.models.Community, {
+        foreignKey: 'communityId',
+        as: 'community',
+    });
 }

--- a/packages/core/src/database/models/associations/community.ts
+++ b/packages/core/src/database/models/associations/community.ts
@@ -109,4 +109,11 @@ export function communityAssociation(sequelize: Sequelize) {
         sourceKey: 'id',
         as: 'claims',
     });
+    sequelize.models.UbiCommunityDemographicsModel.belongsTo(
+        sequelize.models.Community,
+        {
+            foreignKey: 'communityId',
+            as: 'community',
+        }
+    );
 }

--- a/packages/core/src/services/global/globalDemographics.ts
+++ b/packages/core/src/services/global/globalDemographics.ts
@@ -1,262 +1,62 @@
-import { literal, QueryTypes } from 'sequelize';
+import { QueryTypes, Op, literal } from 'sequelize';
+import { Literal } from 'sequelize/types/lib/utils';
+import { Logger } from '../../utils';
 
 import { models, sequelize } from '../../database';
-import {
-    GlobalDemographics,
-    GlobalDemographicsCreationAttributes,
-} from '../../database/models/global/globalDemographics';
-import { UbiCommunityDemographicsCreation } from '../../interfaces/ubi/ubiCommunityDemographics';
+import { GlobalDemographics } from '../../database/models/global/globalDemographics';
 
 export default class GlobalDemographicsService {
-    public static community = models.community;
-    public static ubiCommunityDemographics = models.ubiCommunityDemographics;
-    public static globalDemographics = models.globalDemographics;
-    public static sequelize = sequelize;
+    public community = models.community;
+    public ubiCommunityDemographics = models.ubiCommunityDemographics;
+    public globalDemographics = models.globalDemographics;
+    public sequelize = sequelize;
 
-    public static async add(
-        demographics: GlobalDemographicsCreationAttributes
-    ): Promise<GlobalDemographics> {
-        return await this.globalDemographics.create(demographics);
-    }
-
-    public static async getLast(): Promise<GlobalDemographics[]> {
+    public async get(): Promise<GlobalDemographics[]> {
         return await this.sequelize.query<GlobalDemographics>(
             `select * from globaldemographics where date = (select date from globaldemographics order by date desc limit 1)`,
             { type: QueryTypes.SELECT }
         );
     }
-    public static async calculateCommunitiesDemographics(): Promise<void> {
-        const yesterdayDateOnly = new Date();
-        yesterdayDateOnly.setDate(yesterdayDateOnly.getDate() - 1);
-        const yesterdayDate = yesterdayDateOnly.toISOString().split('T')[0];
 
-        const year = new Date().getUTCFullYear();
-        const demographics: UbiCommunityDemographicsCreation[] =
-            (await this.community.findAll({
+    public async calculate(): Promise<void> {
+        try {
+            const yesterdayDateOnly = new Date(new Date().getTime() - 86400000);
+            yesterdayDateOnly.setHours(0, 0, 0, 0);
+
+            const newDemographics = (await models.ubiCommunityDemographics.findAll({
                 attributes: [
-                    ['id', 'communityId'],
-                    [literal(`'${yesterdayDate}'`), 'date'],
-                    [
-                        literal(
-                            `count(*) FILTER (WHERE ${year}-"beneficiaries->user".year BETWEEN 18 AND 24)`
-                        ),
-                        'ageRange1',
-                    ],
-                    [
-                        literal(
-                            `count(*) FILTER (WHERE ${year}-"beneficiaries->user".year BETWEEN 25 AND 34)`
-                        ),
-                        'ageRange2',
-                    ],
-                    [
-                        literal(
-                            `count(*) FILTER (WHERE ${year}-"beneficiaries->user".year BETWEEN 35 AND 44)`
-                        ),
-                        'ageRange3',
-                    ],
-                    [
-                        literal(
-                            `count(*) FILTER (WHERE ${year}-"beneficiaries->user".year BETWEEN 45 AND 54)`
-                        ),
-                        'ageRange4',
-                    ],
-                    [
-                        literal(
-                            `count(*) FILTER (WHERE ${year}-"beneficiaries->user".year BETWEEN 55 AND 64)`
-                        ),
-                        'ageRange5',
-                    ],
-                    [
-                        literal(
-                            `count(*) FILTER (WHERE ${year}-"beneficiaries->user".year BETWEEN 65 AND 120)`
-                        ),
-                        'ageRange6',
-                    ],
-                    [
-                        literal(
-                            'count(*) FILTER (WHERE "beneficiaries->user".gender = \'m\')'
-                        ),
-                        'male',
-                    ],
-                    [
-                        literal(
-                            'count(*) FILTER (WHERE "beneficiaries->user".gender = \'f\')'
-                        ),
-                        'female',
-                    ],
-                    [
-                        literal(
-                            'count(*) FILTER (WHERE "beneficiaries->user".gender = \'u\')'
-                        ),
-                        'undisclosed',
-                    ],
-                    [literal('count(*)'), 'totalGender'],
+                    'community.country',
+                    [literal(`'${yesterdayDateOnly}'`), 'date'],
+                    [literal(`sum("ageRange1")`), 'ageRange1'],
+                    [literal(`sum("ageRange2")`), 'ageRange2'],
+                    [literal(`sum("ageRange3")`), 'ageRange3'],
+                    [literal(`sum("ageRange4")`), 'ageRange4'],
+                    [literal(`sum("ageRange5")`), 'ageRange5'],
+                    [literal(`sum("ageRange6")`), 'ageRange6'],
+                    [literal(`sum(male)`), 'male'],
+                    [literal(`sum(female)`), 'female'],
+                    [literal(`sum(undisclosed)`), 'undisclosed'],
+                    [literal(`sum("totalGender")`), 'totalGender'],
                 ],
-                include: [
-                    {
-                        model: models.beneficiary,
-                        as: 'beneficiaries',
-                        attributes: [],
-                        where: {
-                            active: true,
-                        },
-                        include: [
-                            {
-                                model: models.appUser,
-                                as: 'user',
-                                required: true,
-                                attributes: [],
-                            },
-                        ],
-                    },
-                ],
+                include: [{
+                    attributes: [],
+                    model: models.community,
+                    as: 'community'
+                }],
                 where: {
-                    visibility: 'public',
-                    status: 'valid',
+                    date: {
+                        [Op.eq]: literal(
+                            `(select date from ubi_community_demographics order by date desc limit 1)`
+                        ),
+                    } as { [Op.eq]: Literal },
                 },
-                group: ['"Community".id'],
-                raw: true,
+                group: ['country'],
+                raw: true
             })) as any;
-        await this.ubiCommunityDemographics.bulkCreate(demographics);
-    }
 
-    public static async calculateDemographics(): Promise<void> {
-        const yesterdayDateOnly = new Date(new Date().getTime() - 86400000);
-        yesterdayDateOnly.setHours(0, 0, 0, 0);
-
-        const newDemographics: GlobalDemographicsCreationAttributes[] = [];
-
-        const sqlAgeRangeQuery = `WITH current_date_year (current_year) as (
-            values (EXTRACT(YEAR from now()))
-         )
-         select c.country
-              , count(*) FILTER (WHERE current_year-u.year BETWEEN 18 AND 24) AS "ageRange1"
-              , count(*) FILTER (WHERE current_year-u.year BETWEEN 25 AND 34) AS "ageRange2"
-              , count(*) FILTER (WHERE current_year-u.year BETWEEN 35 AND 44) AS "ageRange3"
-              , count(*) FILTER (WHERE current_year-u.year BETWEEN 45 AND 54) AS "ageRange4"
-              , count(*) FILTER (WHERE current_year-u.year BETWEEN 55 AND 64) AS "ageRange5"
-              , count(*) FILTER (WHERE current_year-u.year BETWEEN 65 AND 120) AS "ageRange6"
-         from "app_user" u, "current_date_year", beneficiary b, community c
-         where u.address = b.address
-         and b."communityId" = c.id
-         and c.visibility = 'public'
-         and c.status = 'valid'
-         group by c.country`;
-
-        const sqlGenderQuery = `select u.gender, count(u.gender) total, c.country
-        from "app_user" u, beneficiary b, community c
-        where u.address = b.address
-        and b.active = true
-        and b."communityId" = c.id
-        and c.visibility = 'public'
-        and c.status = 'valid'
-        group by c.country, u.gender
-        order by c.country`;
-
-        // query data
-        const rawAgeRange = await this.sequelize.query<{
-            country: string;
-            ageRange1: number;
-            ageRange2: number;
-            ageRange3: number;
-            ageRange4: number;
-            ageRange5: number;
-            ageRange6: number;
-        }>(sqlAgeRangeQuery, { type: QueryTypes.SELECT });
-        const rawGender = await this.sequelize.query<{
-            gender: string;
-            total: string;
-            country: string;
-        }>(sqlGenderQuery, { type: QueryTypes.SELECT });
-
-        // format gender results for easier write
-        const countries: string[] = [];
-        const gender = new Map<
-            string,
-            {
-                male: number;
-                female: number;
-                undisclosed: number;
-                totalGender: number;
-            }
-        >();
-        for (let g = 0; g < rawGender.length; g++) {
-            const element = rawGender[g];
-
-            const gTotal = parseInt(element.total, 10);
-            countries.push(element.country);
-            let previous = gender.get(element.country);
-            if (previous === undefined) {
-                previous = {
-                    male: 0,
-                    female: 0,
-                    undisclosed: 0,
-                    totalGender: 0,
-                };
-            }
-            if (element.gender === 'f') {
-                gender.set(element.country, {
-                    ...previous,
-                    totalGender: previous.totalGender + gTotal,
-                    female: gTotal,
-                });
-            } else if (element.gender === 'm') {
-                gender.set(element.country, {
-                    ...previous,
-                    totalGender: previous.totalGender + gTotal,
-                    male: gTotal,
-                });
-            } else if (element.gender === 'o') {
-                const p = previous.undisclosed;
-                gender.set(element.country, {
-                    ...previous,
-                    totalGender: previous.totalGender + gTotal,
-                    undisclosed: p + gTotal,
-                });
-            } else if (element.gender === 'u') {
-                const p = previous.undisclosed;
-                gender.set(element.country, {
-                    ...previous,
-                    totalGender: previous.totalGender + gTotal,
-                    undisclosed: p + gTotal,
-                });
-            }
+            await this.globalDemographics.bulkCreate(newDemographics);
+        } catch (error) {
+            Logger.error('Failed to calculate globalDemographics: ', error)
         }
-
-        const ageRange = new Map<
-            string,
-            {
-                ageRange1: number;
-                ageRange2: number;
-                ageRange3: number;
-                ageRange4: number;
-                ageRange5: number;
-                ageRange6: number;
-            }
-        >();
-        for (let a = 0; a < rawAgeRange.length; a++) {
-            const element = rawAgeRange[a];
-            countries.push(element.country);
-            ageRange.set(element.country, {
-                ageRange1: element.ageRange1,
-                ageRange2: element.ageRange2,
-                ageRange3: element.ageRange3,
-                ageRange4: element.ageRange4,
-                ageRange5: element.ageRange5,
-                ageRange6: element.ageRange6,
-            });
-        }
-
-        const uniqueCountries = Array.from(new Set(countries));
-        for (let a = 0; a < uniqueCountries.length; a++) {
-            newDemographics.push({
-                date: yesterdayDateOnly,
-                country: uniqueCountries[a],
-                ...ageRange.get(uniqueCountries[a])!,
-                ...gender.get(uniqueCountries[a])!,
-            });
-        }
-
-        await this.globalDemographics.bulkCreate(newDemographics);
     }
 }

--- a/packages/core/src/services/ubi/communityDemographics.ts
+++ b/packages/core/src/services/ubi/communityDemographics.ts
@@ -1,0 +1,113 @@
+import { literal, QueryTypes } from 'sequelize';
+
+import { models, sequelize } from '../../database';
+import { UbiCommunityDemographicsCreation, UbiCommunityDemographics } from '../../interfaces/ubi/ubiCommunityDemographics';
+
+export default class CommunityDemographicsService {
+    public community = models.community;
+    public ubiCommunityDemographics = models.ubiCommunityDemographics;
+    public sequelize = sequelize;
+
+    public async get(): Promise<UbiCommunityDemographics[]> {
+        return await this.sequelize.query<UbiCommunityDemographics>(
+            `select * from ubi_community_demographics where date = (select date from ubi_community_demographics order by date desc limit 1)`,
+            { type: QueryTypes.SELECT }
+        );
+    }
+
+    public async calculate(): Promise<void> {
+        const yesterdayDateOnly = new Date();
+        yesterdayDateOnly.setDate(yesterdayDateOnly.getDate() - 1);
+        const yesterdayDate = yesterdayDateOnly.toISOString().split('T')[0];
+
+        const year = new Date().getUTCFullYear();
+        const demographics: UbiCommunityDemographicsCreation[] =
+            (await this.community.findAll({
+                attributes: [
+                    ['id', 'communityId'],
+                    [literal(`'${yesterdayDate}'`), 'date'],
+                    [
+                        literal(
+                            `count(*) FILTER (WHERE ${year}-"beneficiaries->user".year BETWEEN 18 AND 24)`
+                        ),
+                        'ageRange1',
+                    ],
+                    [
+                        literal(
+                            `count(*) FILTER (WHERE ${year}-"beneficiaries->user".year BETWEEN 25 AND 34)`
+                        ),
+                        'ageRange2',
+                    ],
+                    [
+                        literal(
+                            `count(*) FILTER (WHERE ${year}-"beneficiaries->user".year BETWEEN 35 AND 44)`
+                        ),
+                        'ageRange3',
+                    ],
+                    [
+                        literal(
+                            `count(*) FILTER (WHERE ${year}-"beneficiaries->user".year BETWEEN 45 AND 54)`
+                        ),
+                        'ageRange4',
+                    ],
+                    [
+                        literal(
+                            `count(*) FILTER (WHERE ${year}-"beneficiaries->user".year BETWEEN 55 AND 64)`
+                        ),
+                        'ageRange5',
+                    ],
+                    [
+                        literal(
+                            `count(*) FILTER (WHERE ${year}-"beneficiaries->user".year BETWEEN 65 AND 120)`
+                        ),
+                        'ageRange6',
+                    ],
+                    [
+                        literal(
+                            'count(*) FILTER (WHERE "beneficiaries->user".gender = \'m\')'
+                        ),
+                        'male',
+                    ],
+                    [
+                        literal(
+                            'count(*) FILTER (WHERE "beneficiaries->user".gender = \'f\')'
+                        ),
+                        'female',
+                    ],
+                    [
+                        literal(
+                            'count(*) FILTER (WHERE "beneficiaries->user".gender = \'u\'  OR "beneficiaries->user".gender is null)'
+                        ),
+                        'undisclosed',
+                    ],
+                    [literal('count(*)'), 'totalGender'],
+                ],
+                include: [
+                    {
+                        model: models.beneficiary,
+                        as: 'beneficiaries',
+                        attributes: [],
+                        where: {
+                            active: true,
+                        },
+                        include: [
+                            {
+                                model: models.appUser,
+                                as: 'user',
+                                required: false,
+                                attributes: [],
+                            },
+                        ],
+                    },
+                ],
+                where: {
+                    visibility: 'public',
+                    status: 'valid',
+                },
+                group: ['"Community".id'],
+                raw: true,
+            })) as any;
+
+        await this.ubiCommunityDemographics.bulkCreate(demographics);
+    }
+}

--- a/packages/core/src/services/ubi/index.ts
+++ b/packages/core/src/services/ubi/index.ts
@@ -6,6 +6,7 @@ import CommunityContractService from './communityContract';
 import CommunityDailyMetricsService from './communityDailyMetrics';
 import InflowService from './inflow';
 import ManagerService from './managers';
+import CommunityDemographicsService from './communityDemographics';
 
 export {
     BeneficiaryService,
@@ -16,4 +17,5 @@ export {
     CommunityDailyMetricsService,
     InflowService,
     ManagerService,
+    CommunityDemographicsService,
 };

--- a/packages/core/tests/unit/services/globalDemographics.test.ts
+++ b/packages/core/tests/unit/services/globalDemographics.test.ts
@@ -259,13 +259,13 @@ describe('globalDemographics', () => {
     //         }
     //     },
     // });
-
+    const globalDemographicsService = new GlobalDemographicsService();
     let dbGlobalDemographicsInsertStub: SinonStub;
     let dbSequelizeQueryStub: SinonStub;
 
     before(() => {
         dbSequelizeQueryStub = stub(
-            GlobalDemographicsService.sequelize,
+            globalDemographicsService.sequelize,
             'query'
         );
 
@@ -277,13 +277,13 @@ describe('globalDemographics', () => {
             .returns(Promise.resolve(genderQueryResult as any));
 
         dbGlobalDemographicsInsertStub = stub(
-            GlobalDemographicsService.globalDemographics,
+            globalDemographicsService.globalDemographics,
             'bulkCreate'
         );
     });
 
     it('#calculateDemographics()', async () => {
-        await GlobalDemographicsService.calculateDemographics();
+        await globalDemographicsService.calculate();
         //
         await waitForStubCall(dbGlobalDemographicsInsertStub, 1);
         assert.callCount(dbGlobalDemographicsInsertStub, 1);

--- a/packages/core/tests/unit/services/globalDemographics.test.ts
+++ b/packages/core/tests/unit/services/globalDemographics.test.ts
@@ -1,8 +1,10 @@
 import { Sequelize } from 'sequelize';
 import { stub, assert, match, SinonStub, restore } from 'sinon';
+import { jumpToTomorrowMidnight } from '../../config/utils';
+import tk from 'timekeeper';
 
 import GlobalDemographicsService from '../../../src/services/global/globalDemographics';
-
+import CommunityDemographicsService from '../../../src/services/ubi/communityDemographics';
 import { ManagerAttributes } from '../../../src/database/models/ubi/manager';
 import { AppUser } from '../../../src/interfaces/app/appUser';
 import { BeneficiaryAttributes } from '../../../src/interfaces/ubi/beneficiary';
@@ -14,239 +16,8 @@ import ManagerFactory from '../../factories/manager';
 import BeneficiaryFactory from '../../factories/beneficiary';
 import { models } from '../../../src/database';
 
-const genderQueryResult = [
-    {
-        gender: 'f',
-        total: 2740,
-        country: 'BR',
-    },
-    {
-        gender: 'm',
-        total: 1363,
-        country: 'BR',
-    },
-    {
-        gender: 'u',
-        total: 100,
-        country: 'BR',
-    },
-    {
-        gender: 'm',
-        total: 1,
-        country: 'CV',
-    },
-    {
-        gender: 'f',
-        total: 2,
-        country: 'CV',
-    },
-    {
-        gender: 'u',
-        total: 10,
-        country: 'CV',
-    },
-    {
-        gender: 'o',
-        total: 10,
-        country: 'CV',
-    },
-    {
-        gender: 'f',
-        total: 11,
-        country: 'GH',
-    },
-    {
-        gender: 'm',
-        total: 26,
-        country: 'GH',
-    },
-    {
-        gender: 'o',
-        total: 10,
-        country: 'GH',
-    },
-    {
-        gender: 'f',
-        total: 6,
-        country: 'PH',
-    },
-    {
-        gender: 'm',
-        total: 5,
-        country: 'PH',
-    },
-    {
-        gender: 'u',
-        total: 0,
-        country: 'PH',
-    },
-];
-
-const ageRangeQueryResult: {
-    country: string;
-    ageRange1: number;
-    ageRange2: number;
-    ageRange3: number;
-    ageRange4: number;
-    ageRange5: number;
-    ageRange6: number;
-}[] = [
-    {
-        country: 'NG',
-        ageRange1: 0,
-        ageRange2: 0,
-        ageRange3: 0,
-        ageRange4: 0,
-        ageRange5: 0,
-        ageRange6: 0,
-    },
-    {
-        country: 'VE',
-        ageRange1: 0,
-        ageRange2: 0,
-        ageRange3: 0,
-        ageRange4: 0,
-        ageRange5: 0,
-        ageRange6: 0,
-    },
-    {
-        country: 'HN',
-        ageRange1: 0,
-        ageRange2: 0,
-        ageRange3: 0,
-        ageRange4: 0,
-        ageRange5: 0,
-        ageRange6: 0,
-    },
-    {
-        country: 'GH',
-        ageRange1: 11,
-        ageRange2: 9,
-        ageRange3: 3,
-        ageRange4: 4,
-        ageRange5: 1,
-        ageRange6: 0,
-    },
-    {
-        country: 'BR',
-        ageRange1: 937,
-        ageRange2: 1197,
-        ageRange3: 893,
-        ageRange4: 502,
-        ageRange5: 169,
-        ageRange6: 40,
-    },
-    {
-        country: 'PH',
-        ageRange1: 3,
-        ageRange2: 0,
-        ageRange3: 0,
-        ageRange4: 3,
-        ageRange5: 1,
-        ageRange6: 0,
-    },
-    {
-        country: 'CV',
-        ageRange1: 0,
-        ageRange2: 0,
-        ageRange3: 0,
-        ageRange4: 0,
-        ageRange5: 0,
-        ageRange6: 0,
-    },
-];
-
-const results = [
-    {
-        date: match.any,
-        country: 'BR',
-        ageRange1: 937,
-        ageRange2: 1197,
-        ageRange3: 893,
-        ageRange4: 502,
-        ageRange5: 169,
-        ageRange6: 40,
-        male: 1363,
-        female: 2740,
-        undisclosed: 100,
-        totalGender: 4203,
-    },
-    {
-        date: match.any,
-        country: 'CV',
-        ageRange1: 0,
-        ageRange2: 0,
-        ageRange3: 0,
-        ageRange4: 0,
-        ageRange5: 0,
-        ageRange6: 0,
-        male: 1,
-        female: 2,
-        undisclosed: 20,
-        totalGender: 23,
-    },
-    {
-        date: match.any,
-        country: 'GH',
-        ageRange1: 11,
-        ageRange2: 9,
-        ageRange3: 3,
-        ageRange4: 4,
-        ageRange5: 1,
-        ageRange6: 0,
-        male: 26,
-        female: 11,
-        undisclosed: 10,
-        totalGender: 47,
-    },
-    {
-        date: match.any,
-        country: 'PH',
-        ageRange1: 3,
-        ageRange2: 0,
-        ageRange3: 0,
-        ageRange4: 3,
-        ageRange5: 1,
-        ageRange6: 0,
-        male: 5,
-        female: 6,
-        undisclosed: 0,
-        totalGender: 11,
-    },
-    {
-        date: match.any,
-        country: 'NG',
-        ageRange1: 0,
-        ageRange2: 0,
-        ageRange3: 0,
-        ageRange4: 0,
-        ageRange5: 0,
-        ageRange6: 0,
-        // there are default values
-    },
-    {
-        date: match.any,
-        country: 'VE',
-        ageRange1: 0,
-        ageRange2: 0,
-        ageRange3: 0,
-        ageRange4: 0,
-        ageRange5: 0,
-        ageRange6: 0,
-        // there are default values
-    },
-    {
-        date: match.any,
-        country: 'HN',
-        ageRange1: 0,
-        ageRange2: 0,
-        ageRange3: 0,
-        ageRange4: 0,
-        ageRange5: 0,
-        ageRange6: 0,
-        // there are default values
-    },
-];
+const globalDemographicsService = new GlobalDemographicsService();
+const communityDemographicsService = new CommunityDemographicsService();
 
 async function waitForStubCall(stub: SinonStub<any, any>, callNumber: number) {
     return new Promise((resolve) => {
@@ -258,54 +29,6 @@ async function waitForStubCall(stub: SinonStub<any, any>, callNumber: number) {
         }, 1000);
     });
 }
-
-describe('globalDemographics', () => {
-    // TODO: fix whats in comment to work
-    // stub(database, 'database').returns({
-    //     sequelize: {
-    //         query: ''
-    //     },
-    //     models: {
-    //         globalDemographics: {
-    //             bulkCreate: ''
-    //         }
-    //     },
-    // });
-    const globalDemographicsService = new GlobalDemographicsService();
-    let dbGlobalDemographicsInsertStub: SinonStub;
-    let dbSequelizeQueryStub: SinonStub;
-
-    before(() => {
-        dbSequelizeQueryStub = stub(
-            globalDemographicsService.sequelize,
-            'query'
-        );
-
-        dbSequelizeQueryStub
-            .withArgs(match(/current_date_year/))
-            .returns(Promise.resolve(ageRangeQueryResult as any));
-        dbSequelizeQueryStub
-            .withArgs(match(/gender/))
-            .returns(Promise.resolve(genderQueryResult as any));
-
-        dbGlobalDemographicsInsertStub = stub(
-            globalDemographicsService.globalDemographics,
-            'bulkCreate'
-        );
-    });
-
-    after(() => {
-        restore();
-    });
-
-    it('#calculateDemographics()', async () => {
-        await globalDemographicsService.calculate();
-        //
-        await waitForStubCall(dbGlobalDemographicsInsertStub, 1);
-        assert.callCount(dbGlobalDemographicsInsertStub, 1);
-        assert.calledWith(dbGlobalDemographicsInsertStub.getCall(0), results);
-    });
-});
 
 describe('calculate global demographics', () => {
     let sequelize: Sequelize;
@@ -320,14 +43,44 @@ describe('calculate global demographics', () => {
         sequelize = sequelizeSetup();
         await sequelize.sync();
 
+        const year = new Date().getUTCFullYear();
+        const ageRange1 = year - 18;
+        const ageRange2 = year - 25;
+        const ageRange3 = year - 35;
+        const ageRange4 = year - 45;
+        const ageRange5 = year - 55;
+        const ageRange6 = year - 65;
+
         users = await UserFactory({
-            n: 2,
+            n: 7,
             props: [
                 {
-                    gender: 'm'
+                    gender: 'm',
+                    year: ageRange1
                 },
                 {
-                    gender: 'f'
+                    gender: 'm',
+                    year: ageRange1
+                },
+                {
+                    gender: 'f',
+                    year: ageRange2,
+                },
+                {
+                    gender: 'f',
+                    year: ageRange3,
+                },
+                {
+                    gender: 'f',
+                    year: ageRange4
+                },
+                {
+                    gender: 'u',
+                    year: ageRange5
+                },
+                {
+                    gender: 'u',
+                    year: ageRange6
                 }
             ]
         });
@@ -349,11 +102,11 @@ describe('calculate global demographics', () => {
         ]);
         managers = await ManagerFactory([users[0]], communities[0].id);
         beneficiaries = await BeneficiaryFactory(
-            users.slice(0, 2),
+            users.slice(0, 7),
             communities[0].id
         );
         dbGlobalDemographicsInsertStub = stub(
-            GlobalDemographicsService.globalDemographics,
+            globalDemographicsService.globalDemographics,
             'bulkCreate'
         );
     });
@@ -369,22 +122,27 @@ describe('calculate global demographics', () => {
                 address: users[0].address
             }
         });
-        await GlobalDemographicsService.calculateDemographics();
+
+        await communityDemographicsService.calculate();
+
+        tk.travel(jumpToTomorrowMidnight());
+
+        await globalDemographicsService.calculate();
         await waitForStubCall(dbGlobalDemographicsInsertStub, 1);
         assert.callCount(dbGlobalDemographicsInsertStub, 1);
         assert.calledWith(dbGlobalDemographicsInsertStub.getCall(0), [{
-            ageRange1:'0',
-            ageRange2:'0',
-            ageRange3:'0',
-            ageRange4:'0',
-            ageRange5:'0',
-            ageRange6:'0',
+            ageRange1:'1',
+            ageRange2:'1',
+            ageRange3:'1',
+            ageRange4:'1',
+            ageRange5:'1',
+            ageRange6:'1',
             country: match.any,
             date: match.any,
-            female:1,
-            male:0,
-            totalGender:2,
-            undisclosed:1,
+            female:'3',
+            male:'1',
+            totalGender:'7',
+            undisclosed:'3',
         }]);
     });
 });

--- a/packages/core/tests/unit/services/globalDemographics.test.ts
+++ b/packages/core/tests/unit/services/globalDemographics.test.ts
@@ -125,8 +125,6 @@ describe('calculate global demographics', () => {
 
         await communityDemographicsService.calculate();
 
-        tk.travel(jumpToTomorrowMidnight());
-
         await globalDemographicsService.calculate();
         await waitForStubCall(dbGlobalDemographicsInsertStub, 1);
         assert.callCount(dbGlobalDemographicsInsertStub, 1);

--- a/packages/core/tests/unit/services/globalDemographics.test.ts
+++ b/packages/core/tests/unit/services/globalDemographics.test.ts
@@ -1,7 +1,5 @@
 import { Sequelize } from 'sequelize';
 import { stub, assert, match, SinonStub, restore } from 'sinon';
-import { jumpToTomorrowMidnight } from '../../config/utils';
-import tk from 'timekeeper';
 
 import GlobalDemographicsService from '../../../src/services/global/globalDemographics';
 import CommunityDemographicsService from '../../../src/services/ubi/communityDemographics';

--- a/packages/worker/src/jobs.ts
+++ b/packages/worker/src/jobs.ts
@@ -393,27 +393,6 @@ function cron() {
         true
     );
 
-    // eslint-disable-next-line no-new
-    new CronJob(
-        '0 0 * * *',
-        () => {
-            globalDemographicsService.calculate()
-                .then(() => {
-                    services.app.CronJobExecutedService.add(
-                        'calculateDemographics'
-                    );
-                    utils.Logger.info(
-                        'calculateDemographics successfully executed!'
-                    );
-                })
-                .catch((e) => {
-                    utils.Logger.error('calculateDemographics FAILED! ' + e);
-                });
-        },
-        null,
-        true
-    );
-
     try {
         // eslint-disable-next-line no-new
         new CronJob(
@@ -427,6 +406,19 @@ function cron() {
                         utils.Logger.info(
                             'calculateCommunitiesDemographics successfully executed!'
                         );
+
+                        globalDemographicsService.calculate()
+                            .then(() => {
+                                services.app.CronJobExecutedService.add(
+                                    'calculateDemographics'
+                                );
+                                utils.Logger.info(
+                                    'calculateDemographics successfully executed!'
+                                );
+                            })
+                            .catch((e) => {
+                                utils.Logger.error('calculateDemographics FAILED! ' + e);
+                            });
                     })
                     .catch((e) => {
                         utils.Logger.error(

--- a/packages/worker/src/jobs.ts
+++ b/packages/worker/src/jobs.ts
@@ -235,6 +235,9 @@ function startChainSubscriber(fallback?: boolean): ChainSubscribers {
  * They all follow the API timezone, which should be UTC, same as postgresql.
  */
 function cron() {
+    const globalDemographicsService = new services.global.GlobalDemographicsService();
+    const communityDemographicsService = new services.ubi.CommunityDemographicsService();
+
     // multiple times a day
 
     // every four hour, update exchange rates
@@ -394,7 +397,7 @@ function cron() {
     new CronJob(
         '0 0 * * *',
         () => {
-            services.global.GlobalDemographicsService.calculateDemographics()
+            globalDemographicsService.calculate()
                 .then(() => {
                     services.app.CronJobExecutedService.add(
                         'calculateDemographics'
@@ -416,7 +419,7 @@ function cron() {
         new CronJob(
             '0 0 * * *',
             () => {
-                services.global.GlobalDemographicsService.calculateCommunitiesDemographics()
+                communityDemographicsService.calculate()
                     .then(() => {
                         services.app.CronJobExecutedService.add(
                             'calculateCommunitiesDemographics'

--- a/packages/worker/tests/integration/cron/verifyDeletedAccounts.test.ts
+++ b/packages/worker/tests/integration/cron/verifyDeletedAccounts.test.ts
@@ -386,8 +386,8 @@ describe('[jobs - cron] verifyDeletedAccounts', () => {
                 ageRange6: '0',
                 male: '0',
                 female: '0',
-                undisclosed: '2',
-                totalGender: '2',
+                undisclosed: '3',
+                totalGender: '3',
             },
         ]);
     });

--- a/packages/worker/tests/integration/cron/verifyDeletedAccounts.test.ts
+++ b/packages/worker/tests/integration/cron/verifyDeletedAccounts.test.ts
@@ -11,13 +11,14 @@ describe('[jobs - cron] verifyDeletedAccounts', () => {
     let users: interfaces.app.appUser.AppUser[];
     let communities: interfaces.ubi.community.CommunityAttributes[];
     let dbGlobalDemographicsStub: SinonStub;
+    const communityDemographicsService = new services.ubi.CommunityDemographicsService();
 
     before(async () => {
         sequelize = tests.config.setup.sequelizeSetup();
         await sequelize.sync();
 
         dbGlobalDemographicsStub = stub(
-            services.global.GlobalDemographicsService.ubiCommunityDemographics,
+            communityDemographicsService.ubiCommunityDemographics,
             'bulkCreate'
         );
 
@@ -368,7 +369,7 @@ describe('[jobs - cron] verifyDeletedAccounts', () => {
     });
 
     it('calculateCommunitiesDemographics after delete user (should ignore deleted users)', async () => {
-        await services.global.GlobalDemographicsService.calculateCommunitiesDemographics();
+        await communityDemographicsService.calculate();
         await tests.config.utils.waitForStubCall(dbGlobalDemographicsStub, 1);
         const yesterdayDateOnly = new Date();
         yesterdayDateOnly.setDate(yesterdayDateOnly.getDate() - 1);


### PR DESCRIPTION
This PR fixes [IPCT1-207] at https://impactmarket.atlassian.net/browse/IPCT1-207

## Changes
- remove GlobalDemographicsService.add
- create a CommunityDemographicsService
- move calculateCommunityDemographics to the new CommunityDemographicsService and rename it to calculate
- rename getLast to get in GlobalDemographicsService
- create a get in CommunityDemographicsService
- rename calculateDemographics to calculate in GlobalDemographicsService
- simplify GlobalDemographicsService calculate using the aggregated values from CommunityDemographicsService
- make GlobalDemographicsService and CommunityDemographicsService non static classes
- retest the two services

## New

<!---
Specify what's new. New endpoints, etc.
-->

## Tests

<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->